### PR TITLE
adds `id` to toolRuntimeConfig

### DIFF
--- a/routes/rendering-info.js
+++ b/routes/rendering-info.js
@@ -60,8 +60,15 @@ function getCompiledToolRuntimeConfig(item, target, requestToolRuntimeConfig = {
   // default to the overall config
   let toolRuntimeConfig = overallToolRuntimeConfig;
 
+  // add the item id if given or to a randomized id if not
+  if (item.hasOwnProperty('_id')) {
+    toolRuntimeConfig.id = item._id;
+  } else {
+    toolRuntimeConfig.id = Math.floor(Math.random() * (10 ** 16));
+  }
+
   // if endpoint defines tool runtime config, apply it
-  if (toolEndpointConfig.toolRuntimeConfig) {
+  if (toolEndpointConfig && toolEndpointConfig.toolRuntimeConfig) {
     toolRuntimeConfig = Object.assign(toolRuntimeConfig, toolEndpointConfig.toolRuntimeConfig);
   }
 

--- a/routes/rendering-info.js
+++ b/routes/rendering-info.js
@@ -63,8 +63,6 @@ function getCompiledToolRuntimeConfig(item, target, requestToolRuntimeConfig = {
   // add the item id if given or to a randomized id if not
   if (item.hasOwnProperty('_id')) {
     toolRuntimeConfig.id = item._id;
-  } else {
-    toolRuntimeConfig.id = Math.floor(Math.random() * (10 ** 16));
   }
 
   // if endpoint defines tool runtime config, apply it


### PR DESCRIPTION
This does not add a random number if there is no `_id` yet as the tool should be able to know if the id is one that can be used to get data from the db or not. It should handle creating a random id in case on is really needed for rendering on its own.