### PR TITLE
return rejected promise to gracefully handle the error

### DIFF
--- a/processing/rendering-info-fetcher.js
+++ b/processing/rendering-info-fetcher.js
@@ -16,7 +16,7 @@ function getRenderingInfo(data, target, toolRuntimeConfig) {
   const toolName = data.tool;
 
   if (!isToolConfiguredForTarget(toolName, target, server.settings.app.tools)) {
-    throw Boom.notImplemented(`no endpoint for tool ${toolName} and target ${target}`);
+    return Promise.reject(Boom.notImplemented(`no endpoint for tool ${toolName} and target ${target}`));
   }
 
   const baseUrl = server.settings.app.tools.get(`/${toolName}/baseUrl`, { target: target })


### PR DESCRIPTION
The Exception got not caught correctly resulting in unresponsive server until some timeout if the exception got thrown.