### PR TITLE
feat: add a POST default root proxied to the tool service

### DIFF
--- a/routes/routes.js
+++ b/routes/routes.js
@@ -3,7 +3,8 @@ module.exports = [
   require('./tools/stylesheet'),
   require('./tools/schema'),
   require('./tools/locales'),  
-  require('./tools/default'),
+  require('./tools/default').get,
+  require('./tools/default').post,
 
   require('./editor/targets'),
   require('./editor/tools'),

--- a/routes/tools/default.js
+++ b/routes/tools/default.js
@@ -3,34 +3,55 @@ const Boom = require('boom');
 const fetch = require('node-fetch');
 const querystring = require('querystring');
 
+function handler(request, reply) {
+  const tool = request.server.settings.app.tools.get(`/${request.params.tool}`);
+  if (!tool) {
+    return reply(Boom.notFound(`Tool ${request.params.tool} is not known`));
+  }
+
+  let queryString = '';
+  if (request.query) {
+    queryString = querystring.stringify(request.query);
+  }
+
+  return reply.proxy({
+    uri: `${tool.baseUrl}/${request.params.path}?${queryString}`,
+  })
+}
+
 module.exports = {
-  path: '/tools/{tool}/{path*}',
-  method: 'GET',
-  config: {
-    description: 'Proxies the request to the renderer service for the given tool as defined in the environment',
-    tags: ['api', 'reader-facing'],
-    validate: {
-      params: {
-        tool: Joi.string().required(),
-        path: Joi.string().required()
+  get: {
+    path: '/tools/{tool}/{path*}',
+    method: 'GET',
+    config: {
+      description: 'Proxies the request to the renderer service for the given tool as defined in the environment',
+      tags: ['api', 'reader-facing'],
+      validate: {
+        params: {
+          tool: Joi.string().required(),
+          path: Joi.string().required()
+        }
       }
-    }
+    },
+    handler: handler
   },
-  handler: (request, reply) => {
-    const tool = request.server.settings.app.tools.get(`/${request.params.tool}`);
-
-    if (!tool) {
-      return reply(Boom.notFound(`Tool ${request.params.tool} is not known`));
-    }
-
-    let queryString = '';
-    if (request.query) {
-      queryString = querystring.stringify(request.query);
-    }
-
-    return reply.proxy({
-      uri: `${tool.baseUrl}/${request.params.path}?${queryString}`
-    })
-
+  post: {
+    path: '/tools/{tool}/{path*}',
+    method: 'POST',
+    config: {
+      description: 'Proxies the request to the renderer service for the given tool as defined in the environment',
+      tags: ['api', 'reader-facing'],
+      validate: {
+        params: {
+          tool: Joi.string().required(),
+          path: Joi.string().required()
+        }
+      },
+      payload: {
+        output: 'stream',
+        parse: false
+      }
+    },
+    handler: handler
   }
 }


### PR DESCRIPTION
This makes the default proxied route to the tools services available for POST as well. It is used by the editor for the new `dynamicEnum` and `availabilityChecks` tool schema options.