### PR TITLE
(rendering-info): pass itemStateInDb property to tool

### DIFF
--- a/docs/developing-tools.md
+++ b/docs/developing-tools.md
@@ -25,6 +25,8 @@ Additionally you can specify an endpoint to get rendering information for a give
           payload: {
             // item gets validated against given schema
             item: schema,
+            // true if item was read from database, false if not (useful if you want to use the appendItemToPayload query from Q servers tool-default route)
+            itemStateInDb: Joi.boolean(),
             // one can pass further runtime configuration
             toolRuntimeConfig: Joi.object()
           }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "lab -a code -t 80 -c -P tests -m 3000 --verbose --leaks",
+    "test": "lab -a code -t 86 -c -P tests -m 3000 --verbose --leaks",
     "start:prod": "APP_ENV=prod node index.js",
     "start:staging": "APP_ENV=staging node index.js",
     "start:local": "APP_ENV=local node index.js"

--- a/plugins/core/rendering-info/helpers.js
+++ b/plugins/core/rendering-info/helpers.js
@@ -5,7 +5,7 @@ const deepmerge = require('deepmerge');
 const Boom = require('boom');
 const deleteMetaProperties = require('../../../helper/meta-properties').deleteMetaProperties;
 
-async function getRenderingInfo(item, baseUrl, endpointConfig, toolRuntimeConfig) {
+async function getRenderingInfo(item, baseUrl, endpointConfig, toolRuntimeConfig, itemStateInDb) {
   let requestUrl;
   if (endpointConfig.hasOwnProperty('path')) {
     requestUrl = `${baseUrl}${endpointConfig.path}`;
@@ -29,6 +29,7 @@ async function getRenderingInfo(item, baseUrl, endpointConfig, toolRuntimeConfig
   // strip the meta properties before sending the item to the tool service
   const body = {
     item: deleteMetaProperties(clone(item)),
+    itemStateInDb: itemStateInDb,
     toolRuntimeConfig: toolRuntimeConfig
   }
 

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -261,6 +261,26 @@ lab.experiment('core rendering-info', () => {
     expect(response.statusCode).to.be.equal(500);
   });
 
+  it('passes itemStateInDb to the tool rendering-info endpoint if item is coming from db', async () => {
+    const response = await server.inject('/rendering-info/mock-item-active/pub1');
+    expect(response.result.markup).to.be.equal(`<h1>title - itemStateInDb: true</h1>`);
+  });
+
+  it('passes itemStateInDb to the tool rendering-info endpoint if item is not from db', async () => {
+    const response = await server.inject({
+      url: '/rendering-info/pub1',
+      method: 'POST',
+      payload: JSON.stringify({
+        item: {
+          _id: 'mock-item-active',
+          title: 'title',
+          tool: 'tool1',
+        }
+      })
+    });
+    expect(response.result.markup).to.be.equal(`<h1>title - itemStateInDb: false</h1>`);
+  });
+
 });
 
 lab.experiment('core editor endpoints', () => {

--- a/test/mock/tool1.js
+++ b/test/mock/tool1.js
@@ -71,7 +71,7 @@ server.route({
   },
   handler: function(request, h) {
     return {
-      markup: `<h1>${request.payload.item.title}</h1>`,
+      markup: `<h1>${request.payload.item.title} - itemStateInDb: ${request.payload.itemStateInDb}</h1>`,
       stylesheets: [
         {
           name: 'mockstyle'


### PR DESCRIPTION
This property can be used to determine in the tool if one could use the `appendItemToPayload` query parameter of tool-default route.