### PR TITLE
Feat allow better cache handling

### DIFF
--- a/plugins/core/base/index.js
+++ b/plugins/core/base/index.js
@@ -34,6 +34,9 @@ module.exports = {
       return cacheControlDirectives;
     });
 
+    server.event('item.new');
+    server.event('item.update');
+
     await server.route([
       require('./routes/item.js').get,
       require('./routes/item.js').post,

--- a/plugins/core/base/routes/item.js
+++ b/plugins/core/base/routes/item.js
@@ -97,7 +97,13 @@ module.exports = {
   
           docDiff._id = res.id;
           docDiff._rev = res.rev;
-  
+
+          const savedDoc = Object.assign(request.payload, {
+            _id: res.id,
+            _rev: res.rev
+          });
+          request.server.events.emit('item.new', savedDoc);
+
           return resolve(docDiff);
         })
       });
@@ -161,6 +167,11 @@ module.exports = {
           if (err) {
             return reject(new Boom(err.description, { statusCode: err.statusCode } ));
           }
+
+          const savedDoc = Object.assign(doc, {
+            _rev: res.rev
+          });
+          request.server.events.emit('item.update', savedDoc);
 
           docDiff._rev = res.rev;
           return resolve(docDiff);

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -58,7 +58,8 @@ function getGetRenderingInfoRoute(config) {
         } else {
           const renderingInfo = await request.server.methods.renderingInfo.cached.getRenderingInfoForId(request.params.id, request.params.target, requestToolRuntimeConfig, request.query.ignoreInactive);
           return h.response(renderingInfo)
-            .header('cache-control', config.cacheControlHeader);
+            .header('cache-control', config.cacheControlHeader)
+            .header('cache-tag', `q.rendering-info.${request.params.id}`);
         }
       } catch (err) {
         if (err.stack) {
@@ -193,7 +194,7 @@ module.exports = {
 
     // calculate the cache control header from options given
     const cacheControlDirectives = await server.methods.getCacheControlDirectivesFromConfig(options.get('/cache/cacheControl'));
-    const cacheControlHeader = cacheControlDirectives.join(', ');
+    const cacheControlHeader = cacheControlDirectives.join(',');
 
     const routesConfig = {
       cacheControlHeader: cacheControlHeader

--- a/plugins/screenshot/routes.js
+++ b/plugins/screenshot/routes.js
@@ -76,7 +76,8 @@ module.exports = {
           const imageResponse = h.response(screenshotBuffer);
           imageResponse
             .type('image/png')
-            .header('cache-control', cacheControlHeader);
+            .header('cache-control', cacheControlHeader)
+            .header('cache-tag', `q.plugins.screenshot.${request.params.id}`);
           return imageResponse;
         }
       },

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -319,6 +319,14 @@ lab.experiment('core rendering-info', () => {
     expect(response.result.markup).to.be.equal(`<h1>title - itemStateInDb: false</h1>`);
   });
 
+  it('returnes rendering-info with correct cache-control and cache-tag headers', { timeout: 5000, plan: 3 }, async () => {
+    const itemId = 'mock-item-active';
+    const response = await server.inject('/rendering-info/mock-item-active/pub1');
+    expect(response.statusCode).to.be.equal(200);
+    expect(response.headers['cache-control']).to.be.equal('public,max-age=1,s-maxage=1,stale-while-revalidate=1,stale-if-error=1');
+    expect(response.headers['cache-tag']).to.be.equal(`q.rendering-info.${itemId}`);
+  });
+
 });
 
 lab.experiment('core editor endpoints', () => {
@@ -374,11 +382,13 @@ lab.experiment('core schema endpoints', () => {
 });
 
 lab.experiment('screenshot plugin', async () => {
-  await it('returnes a screenshot with correct cache-control headers', { timeout: 5000, plan: 3 }, async () => {
+  await it('returnes a screenshot with correct cache-control and cache-tag headers', { timeout: 5000, plan: 4 }, async () => {
+    const itemId = 'mock-item-active';
     const response = await server.inject('/screenshot/mock-item-active.png?target=pub1&width=500');
     expect(response.statusCode).to.be.equal(200);
     expect(response.headers['content-type']).to.be.equal('image/png');
-    expect(response.headers['cache-control']).to.be.equal("public,max-age=1,s-maxage=1,stale-while-revalidate=1,stale-if-error=1");
+    expect(response.headers['cache-control']).to.be.equal('public,max-age=1,s-maxage=1,stale-while-revalidate=1,stale-if-error=1');
+    expect(response.headers['cache-tag']).to.be.equal(`q.plugins.screenshot.${itemId}`);
   });
 });
 

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -168,6 +168,44 @@ lab.experiment('core item', () => {
     }
   });
 
+  it('should emit item.new event if new item is saved', { plan: 1 }, async () => {
+    const id = 'fix-id-to-better-test-the-case';
+    const handler = (item) => {
+      expect(item._id).to.be.equal(id);
+    }
+    server.events.once('item.new', handler);
+    const request = {
+      method: 'POST',
+      credentials: {username: 'user', password: 'pass'},
+      url: '/item',
+      payload: {
+        _id: 'fix-id-to-better-test-the-case',
+        title: 'some-new-item',
+        tool: 'tool1',
+        foo: 'bar'
+      }
+    };
+    const response = await server.inject(request);
+  });
+
+  it('should emit item.update event if new item is saved', { plan: 1 }, async () => {
+    const id = 'mock-item-to-test-edits';
+    const handler = (item) => {
+      expect(item._id).to.be.equal(id);
+    }
+    server.events.once('item.update', handler);
+
+    const itemResponse = await server.inject('/item/mock-item-to-test-edits');
+    const item = JSON.parse(itemResponse.payload);
+    const request = {
+      method: 'PUT',
+      credentials: {username: 'user', password: 'pass'},
+      url: '/item',
+      payload: item
+    };
+    const response = await server.inject(request);
+  });
+
 });
 
 lab.experiment('core tool proxy routes', () => {
@@ -336,7 +374,7 @@ lab.experiment('core schema endpoints', () => {
 });
 
 lab.experiment('screenshot plugin', async () => {
-  await it('returnes a screenshot with correct cache-control headers', { timeout: 5000 }, async () => {
+  await it('returnes a screenshot with correct cache-control headers', { timeout: 5000, plan: 3 }, async () => {
     const response = await server.inject('/screenshot/mock-item-active.png?target=pub1&width=500');
     expect(response.statusCode).to.be.equal(200);
     expect(response.headers['content-type']).to.be.equal('image/png');


### PR DESCRIPTION
- send cache-tag header in /rendering-info and /screenshot responses (to be able to purge the CDN by tag)
- emit `item.new` and `item.update` events to listen for in the Q server implementation and purge the CDN cache when item updates