### PR TITLE
Feat cdn plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -155,11 +155,15 @@
       "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "aproba": {
       "version": "1.2.0",
@@ -1302,8 +1306,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "commoner": {
       "version": "0.10.8",
@@ -2164,6 +2167,11 @@
       "integrity": "sha1-l2ug9uu3PrWAZEvwjVPqhKxAxJA=",
       "dev": true
     },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -2545,8 +2553,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "4.9.0",
@@ -3071,8 +3078,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.1.4",
@@ -3144,6 +3150,19 @@
         "lodash.pad": "4.5.1",
         "lodash.padend": "4.6.1",
         "lodash.padstart": "4.6.1"
+      }
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
       }
     },
     "get-folder-size": {
@@ -3528,7 +3547,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       },
@@ -3536,8 +3554,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
     },
@@ -4035,6 +4052,17 @@
         "to-string-symbols-supported-x": "1.0.0"
       }
     },
+    "is-my-json-valid": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
     "is-nan-x": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.1.tgz",
@@ -4097,6 +4125,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -4151,8 +4184,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jkroso-type": {
       "version": "1.1.1",
@@ -4239,8 +4271,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -4259,6 +4290,11 @@
         "json-stringify-safe": "5.0.1",
         "xtend": "4.0.1"
       }
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -4299,6 +4335,208 @@
           "requires": {
             "amdefine": "1.0.1"
           }
+        }
+      }
+    },
+    "keycdn": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/keycdn/-/keycdn-0.2.0.tgz",
+      "integrity": "sha1-J1TT5jj85uY4vXoRgYTOa0tbNGk=",
+      "requires": {
+        "request": "2.55.0"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+        },
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
+        },
+        "bl": {
+          "version": "0.9.5",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+          "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+          "requires": {
+            "readable-stream": "1.0.34"
+          }
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "caseless": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+          "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+          "requires": {
+            "async": "0.9.2",
+            "combined-stream": "0.0.7",
+            "mime-types": "2.0.14"
+          }
+        },
+        "har-validator": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
+          "requires": {
+            "bluebird": "2.11.0",
+            "chalk": "1.1.3",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.16.1"
+          }
+        },
+        "hawk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "0.1.5",
+            "ctype": "0.5.3"
+          }
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "requires": {
+            "mime-db": "1.12.0"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "oauth-sign": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+          "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM="
+        },
+        "qs": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+          "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o="
+        },
+        "request": {
+          "version": "2.55.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
+          "requires": {
+            "aws-sign2": "0.5.0",
+            "bl": "0.9.5",
+            "caseless": "0.9.0",
+            "combined-stream": "0.0.7",
+            "forever-agent": "0.6.1",
+            "form-data": "0.2.0",
+            "har-validator": "1.8.0",
+            "hawk": "2.3.1",
+            "http-signature": "0.10.1",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.0.14",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.6.0",
+            "qs": "2.4.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -7181,7 +7419,6 @@
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -7192,20 +7429,17 @@
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
@@ -7630,7 +7864,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       },
@@ -7638,8 +7871,7 @@
         "hoek": {
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         }
       }
     },
@@ -8759,14 +8991,12 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "0.1.1",
@@ -9180,7 +9410,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       },
@@ -9188,8 +9417,7 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
@@ -9243,8 +9471,7 @@
     "tunnel-agent": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -9667,8 +9894,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "inert": "^5.0.1",
     "joi": "^13.0.2",
     "json-schema-ref-parser": "^4.0.4",
+    "keycdn": "^0.2.0",
     "nano": "^6.4.2",
     "nano-promises": "^1.2.0",
     "node-fetch": "^1.7.3",

--- a/plugins/cdn/keycdn/index.js
+++ b/plugins/cdn/keycdn/index.js
@@ -7,6 +7,7 @@ function getCacheTagForId(id) {
 
 module.exports = {
   name: 'q-cdn-keycdn',
+  dependencies: ['q-base'],
   register: async function(server, options) {
 
     Hoek.assert(typeof options.zoneId === 'string', 'options.zoneId must be a string');
@@ -34,13 +35,14 @@ module.exports = {
         return h.continue;
       }
 
-      // add a tag if there is an id property in the route params
-      if (request.params.hasOwnProperty('id')) {
-        return h.response(response)
-          .header('cache-tag', getCacheTagForId(request.params.id))
+      // if there is no id property in the route params: continue
+      if (!request.params.hasOwnProperty('id')) {
+        return h.continue;
       }
 
-      return h.continue;
+      // if all prerequisites are given, actually add the cache-tag header
+      return h.response(response)
+        .header('cache-tag', getCacheTagForId(request.params.id))
     });
 
     const keycdn = new KeyCDN(options.apiKey);

--- a/plugins/cdn/keycdn/index.js
+++ b/plugins/cdn/keycdn/index.js
@@ -1,0 +1,66 @@
+const KeyCDN = require('keycdn');
+const Hoek = require('hoek');
+
+function getCacheTagForId(id) {
+  return `q-item-id-${id}`;
+}
+
+module.exports = {
+  name: 'q-cdn-keycdn',
+  register: async function(server, options) {
+
+    Hoek.assert(typeof options.zoneId === 'string', 'options.zoneId must be a string');
+    Hoek.assert(typeof options.apiKey === 'string', 'options.apiKey must be a string');
+
+    if (!options.xPullKey) {
+      options.xPullKey = 'KeyCDN'; // this is the default at keycdn
+    }
+
+    server.ext('onPreResponse', async (request, h) => {
+      const response = request.response;
+
+      // if the request is not coming from keycdn: continue
+      if (!request.headers.hasOwnProperty('x-pull') || request.headers['x-pull'] !== options.xPullKey) {
+        return h.continue;
+      }
+
+      // if no cache-control header is present: continue
+      if (!response.headers.hasOwnProperty('cache-control')) {
+        return h.continue;
+      }
+
+      // if cache-control is set to no-cache: continue
+      if (response.headers['cache-control'] === 'no-cache') {
+        return h.continue;
+      }
+
+      // add a tag if there is an id property in the route params
+      if (request.params.hasOwnProperty('id')) {
+        return h.response(response)
+          .header('cache-tag', getCacheTagForId(request.params.id))
+      }
+
+      return h.continue;
+    });
+
+    const keycdn = new KeyCDN(options.apiKey);
+    server.events.on('item.update', (item) => {
+      const tagsToPurge = [
+        getCacheTagForId(item._id),
+      ];
+      // dryRun is set for testing to not actually send the request to keycdn
+      /* $lab:coverage:off$ */
+      if (options.dryRun) {
+        return;
+      }
+      keycdn.del(`zones/purgeurl/${options.zoneId}.json`, { tags: tagsToPurge }, (err, res) => {
+        if (err) {
+          server.log(['error'], err);
+        } else {
+          server.log(['info'], res);
+        }
+      });
+      /* $lab:coverage:on$ */
+    });
+  }
+};

--- a/plugins/core/base/index.js
+++ b/plugins/core/base/index.js
@@ -34,6 +34,9 @@ module.exports = {
       return cacheControlDirectives;
     });
 
+    server.event('item.new');
+    server.event('item.update');
+
     await server.route([
       require('./routes/item.js').get,
       require('./routes/item.js').post,

--- a/plugins/core/base/routes/item.js
+++ b/plugins/core/base/routes/item.js
@@ -97,7 +97,13 @@ module.exports = {
   
           docDiff._id = res.id;
           docDiff._rev = res.rev;
-  
+
+          const savedDoc = Object.assign(request.payload, {
+            _id: res.id,
+            _rev: res.rev
+          });
+          request.server.events.emit('item.new', savedDoc);
+
           return resolve(docDiff);
         })
       });
@@ -161,6 +167,11 @@ module.exports = {
           if (err) {
             return reject(new Boom(err.description, { statusCode: err.statusCode } ));
           }
+
+          const savedDoc = Object.assign(doc, {
+            _rev: res.rev
+          });
+          request.server.events.emit('item.update', savedDoc);
 
           docDiff._rev = res.rev;
           return resolve(docDiff);

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -168,6 +168,44 @@ lab.experiment('core item', () => {
     }
   });
 
+  it('should emit item.new event if new item is saved', { plan: 1 }, async () => {
+    const id = 'fix-id-to-better-test-the-case';
+    const handler = (item) => {
+      expect(item._id).to.be.equal(id);
+    }
+    server.events.once('item.new', handler);
+    const request = {
+      method: 'POST',
+      credentials: {username: 'user', password: 'pass'},
+      url: '/item',
+      payload: {
+        _id: 'fix-id-to-better-test-the-case',
+        title: 'some-new-item',
+        tool: 'tool1',
+        foo: 'bar'
+      }
+    };
+    const response = await server.inject(request);
+  });
+
+  it('should emit item.update event if new item is saved', { plan: 1 }, async () => {
+    const id = 'mock-item-to-test-edits';
+    const handler = (item) => {
+      expect(item._id).to.be.equal(id);
+    }
+    server.events.once('item.update', handler);
+
+    const itemResponse = await server.inject('/item/mock-item-to-test-edits');
+    const item = JSON.parse(itemResponse.payload);
+    const request = {
+      method: 'PUT',
+      credentials: {username: 'user', password: 'pass'},
+      url: '/item',
+      payload: item
+    };
+    const response = await server.inject(request);
+  });
+
 });
 
 lab.experiment('core tool proxy routes', () => {
@@ -336,7 +374,7 @@ lab.experiment('core schema endpoints', () => {
 });
 
 lab.experiment('screenshot plugin', async () => {
-  await it('returnes a screenshot with correct cache-control headers', { timeout: 5000 }, async () => {
+  await it('returnes a screenshot with correct cache-control headers', { timeout: 5000, plan: 3 }, async () => {
     const response = await server.inject('/screenshot/mock-item-active.png?target=pub1&width=500');
     expect(response.statusCode).to.be.equal(200);
     expect(response.headers['content-type']).to.be.equal('image/png');

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -404,4 +404,47 @@ lab.experiment('fixture data plugin', () => {
     expect(response.result.length).to.be.equal(1);
     expect(response.result[0]._id).to.be.equal('tool1-0');
   })
-})
+});
+
+lab.experiment('keycdn plugin', () => {
+  it('returnes with cache-tag header if there is an id in the route params and request is from keycdn', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      headers: {
+        'x-pull': 'KeyCDN'
+      },
+      url: '/rendering-info/mock-item-active/pub1'
+    });
+    expect(response.headers['cache-tag']).to.be.equal('q-item-id-mock-item-active');
+  });
+
+  it('returnes no cache-tag header if there is an id in the route params and request is not from keycdn', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/rendering-info/mock-item-active/pub1'
+    });
+    expect(response.headers['cache-tag']).to.be.undefined();
+  });
+
+  it('returnes no cache-tag header if there is no id in the route params and request is from keycdn', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      headers: {
+        'x-pull': 'KeyCDN'
+      },
+      url: '/tools/tool1/display-options-schema.json'
+    });
+    expect(response.headers['cache-tag']).to.be.undefined();
+  });
+
+  it('returnes no cache-tag header if there is an id in the route params and request is from keycdn but cache-control is no-cache', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      headers: {
+        'x-pull': 'KeyCDN'
+      },
+      url: '/rendering-info/mock-item-active/pub1?noCache=true'
+    });
+    expect(response.headers['cache-tag']).to.be.undefined();
+  });
+});

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -188,7 +188,7 @@ lab.experiment('core item', () => {
     const response = await server.inject(request);
   });
 
-  it('should emit item.update event if an existing itemm is updated', { plan: 1 }, async () => {
+  it('should emit item.update event if an existing item is updated', { plan: 1 }, async () => {
     const id = 'mock-item-to-test-edits';
     const handler = (item) => {
       expect(item._id).to.be.equal(id);

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -188,7 +188,7 @@ lab.experiment('core item', () => {
     const response = await server.inject(request);
   });
 
-  it('should emit item.update event if new item is saved', { plan: 1 }, async () => {
+  it('should emit item.update event if an existing itemm is updated', { plan: 1 }, async () => {
     const id = 'mock-item-to-test-edits';
     const handler = (item) => {
       expect(item._id).to.be.equal(id);
@@ -374,7 +374,7 @@ lab.experiment('core schema endpoints', () => {
 });
 
 lab.experiment('screenshot plugin', async () => {
-  await it('returnes a screenshot with correct cache-control headers', { timeout: 5000, plan: 3 }, async () => {
+  await it('returns a screenshot with correct cache-control headers', { timeout: 5000, plan: 3 }, async () => {
     const response = await server.inject('/screenshot/mock-item-active.png?target=pub1&width=500');
     expect(response.statusCode).to.be.equal(200);
     expect(response.headers['content-type']).to.be.equal('image/png');
@@ -407,7 +407,7 @@ lab.experiment('fixture data plugin', () => {
 });
 
 lab.experiment('keycdn plugin', () => {
-  it('returnes with cache-tag header if there is an id in the route params and request is from keycdn', async () => {
+  it('returns with cache-tag header if there is an id in the route params and request is from keycdn', async () => {
     const response = await server.inject({
       method: 'GET',
       headers: {
@@ -418,7 +418,7 @@ lab.experiment('keycdn plugin', () => {
     expect(response.headers['cache-tag']).to.be.equal('q-item-id-mock-item-active');
   });
 
-  it('returnes no cache-tag header if there is an id in the route params and request is not from keycdn', async () => {
+  it('returns no cache-tag header if there is an id in the route params and request is not from keycdn', async () => {
     const response = await server.inject({
       method: 'GET',
       url: '/rendering-info/mock-item-active/pub1'
@@ -426,7 +426,7 @@ lab.experiment('keycdn plugin', () => {
     expect(response.headers['cache-tag']).to.be.undefined();
   });
 
-  it('returnes no cache-tag header if there is no id in the route params and request is from keycdn', async () => {
+  it('returns no cache-tag header if there is no id in the route params and request is from keycdn', async () => {
     const response = await server.inject({
       method: 'GET',
       headers: {
@@ -437,7 +437,7 @@ lab.experiment('keycdn plugin', () => {
     expect(response.headers['cache-tag']).to.be.undefined();
   });
 
-  it('returnes no cache-tag header if there is an id in the route params and request is from keycdn but cache-control is no-cache', async () => {
+  it('returns no cache-tag header if there is an id in the route params and request is from keycdn but cache-control is no-cache', async () => {
     const response = await server.inject({
       method: 'GET',
       headers: {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -77,5 +77,13 @@ module.exports = [
         }
       }
     }
+  },
+  {
+    plugin: require('../plugins/cdn/keycdn'),
+    options: {
+      zoneId: 'some-zone-id',
+      apiKey: 'some-api-key',
+      dryRun: true
+    }
   }
 ];


### PR DESCRIPTION
- emits `item.new` or `item.update` event if item is saved
- keycdn plugin transparently adds `cache-tag` header if request is from keycdn and the route has a param `id` to purge the cache for this tag on `item.update` event