### PR TITLE
Feat screenshot tool runtime config

### DIFF
--- a/plugins/screenshot/routes.js
+++ b/plugins/screenshot/routes.js
@@ -5,7 +5,7 @@ const getScreenshot = require("./helpers.js").getScreenshot;
 const getInnerWidth = require("./helpers.js").getInnerWidth;
 
 module.exports = {
-  getRoutes: function(cacheControlHeader) {
+  getRoutes: function (cacheControlHeader) {
     return [
       {
         path: "/screenshot/{id}.png",
@@ -21,11 +21,13 @@ module.exports = {
               dpr: Joi.number().optional(),
               background: Joi.string().optional(),
               padding: Joi.string()
-                .regex(
-                  /^$|^(([0-9.]+)(px|em|ex|%|in|cm|mm|pt|pc|vh|vw)?([ ])?){1,4}$/
-                )
+                .regex(/^$|^(([0-9.]+)(px|em|ex|%|in|cm|mm|pt|pc|vh|vw)?([ ])?){1,4}$/)
                 .optional(),
-              wait: Joi.optional()
+              wait: Joi.optional(),
+              toolRuntimeConfig: Joi.object().optional()
+            },
+            options: {
+              allowUnknown: true
             }
           },
           tags: ["api"]
@@ -47,7 +49,7 @@ module.exports = {
             throw Boom.badRequest("the target is not of type web");
           }
 
-          const toolRuntimeConfig = {};
+          const toolRuntimeConfig = request.query.toolRuntimeConfig || {};
 
           // check if there is a given width, if so, send it in toolRuntimeConfig to the rendering-info endpoint
           const width = getInnerWidth(
@@ -69,7 +71,7 @@ module.exports = {
           const response = await request.server.inject({
             url: `/rendering-info/${request.params.id}/${
               request.query.target
-            }?toolRuntimeConfig=${JSON.stringify(toolRuntimeConfig)}`
+              }?toolRuntimeConfig=${JSON.stringify(toolRuntimeConfig)}`
           });
 
           if (response.statusCode !== 200) {
@@ -113,7 +115,7 @@ module.exports = {
 
           const screenshotBuffer = await getScreenshot(
             `${server.info.protocol}://localhost:${
-              server.info.port
+            server.info.port
             }/screenshot/empty-page.html`,
             renderingInfo.markup,
             scripts,

--- a/plugins/screenshot/routes.js
+++ b/plugins/screenshot/routes.js
@@ -1,15 +1,15 @@
-const Boom = require('boom');
-const Joi = require('joi');
+const Boom = require("boom");
+const Joi = require("joi");
 
-const getScreenshot = require('./helpers.js').getScreenshot;
-const getInnerWidth = require('./helpers.js').getInnerWidth;
+const getScreenshot = require("./helpers.js").getScreenshot;
+const getInnerWidth = require("./helpers.js").getInnerWidth;
 
 module.exports = {
   getRoutes: function(cacheControlHeader) {
     return [
       {
-        path: '/screenshot/{id}.png',
-        method: 'GET',
+        path: "/screenshot/{id}.png",
+        method: "GET",
         options: {
           validate: {
             params: {
@@ -20,55 +20,73 @@ module.exports = {
               width: Joi.number().required(),
               dpr: Joi.number().optional(),
               background: Joi.string().optional(),
-              padding: Joi.string().regex(/^$|^(([0-9.]+)(px|em|ex|%|in|cm|mm|pt|pc|vh|vw)?([ ])?){1,4}$/).optional(),
+              padding: Joi.string()
+                .regex(
+                  /^$|^(([0-9.]+)(px|em|ex|%|in|cm|mm|pt|pc|vh|vw)?([ ])?){1,4}$/
+                )
+                .optional(),
               wait: Joi.optional()
             }
           },
-          tags: ['api']
+          tags: ["api"]
         },
         handler: async (request, h) => {
           const targetKey = request.query.target;
 
-          const target = request.server.settings.app.targets.get(`/`)
+          const target = request.server.settings.app.targets
+            .get(`/`)
             .find(configuredTarget => {
-              return configuredTarget.key === request.query.target
-            })
+              return configuredTarget.key === request.query.target;
+            });
 
           if (!target) {
-            throw Boom.badRequest('no such target');
+            throw Boom.badRequest("no such target");
           }
 
-          if (target.type !== 'web') {
-            throw Boom.badRequest('the target is not of type web');
+          if (target.type !== "web") {
+            throw Boom.badRequest("the target is not of type web");
           }
 
           const toolRuntimeConfig = {};
 
           // check if there is a given width, if so, send it in toolRuntimeConfig to the rendering-info endpoint
-          const width = getInnerWidth(request.query.width, request.query.padding);
+          const width = getInnerWidth(
+            request.query.width,
+            request.query.padding
+          );
           if (width) {
             toolRuntimeConfig.size = {
-              width: [{
-                value: width,
-                unit: 'px',
-                comparison: '='
-              }]
-            }
+              width: [
+                {
+                  value: width,
+                  unit: "px",
+                  comparison: "="
+                }
+              ]
+            };
           }
 
           const response = await request.server.inject({
-            url: `/rendering-info/${request.params.id}/${request.query.target}?toolRuntimeConfig=${JSON.stringify(toolRuntimeConfig)}`
+            url: `/rendering-info/${request.params.id}/${
+              request.query.target
+            }?toolRuntimeConfig=${JSON.stringify(toolRuntimeConfig)}`
           });
-          
+
           if (response.statusCode !== 200) {
-            throw new Boom(response.statusMessage, { statusCode: response.statusCode } );
+            throw new Boom(response.statusMessage, {
+              statusCode: response.statusCode
+            });
           }
 
           const server = response.request.server;
           const renderingInfo = JSON.parse(response.payload);
 
-          let scripts = await server.methods.plugins.q.screenshot.getScripts(renderingInfo);
-          let stylesheets = await server.methods.plugins.q.screenshot.getStylesheets(renderingInfo);
+          let scripts = await server.methods.plugins.q.screenshot.getScripts(
+            renderingInfo
+          );
+          let stylesheets = await server.methods.plugins.q.screenshot.getStylesheets(
+            renderingInfo
+          );
 
           // add scripts and stylesheets from publication config
           if (Array.isArray(target.context.scripts)) {
@@ -81,9 +99,9 @@ module.exports = {
           const config = {
             width: request.query.width,
             dpr: request.query.dpr || 1,
-            padding: request.query.padding || '0',
-            background: request.query.background,
-          }
+            padding: request.query.padding || "0",
+            background: request.query.background
+          };
 
           if (request.query.wait !== undefined) {
             if (Number.isNaN(parseInt(request.query.wait))) {
@@ -93,20 +111,28 @@ module.exports = {
             }
           }
 
-          const screenshotBuffer = await getScreenshot(`${server.info.protocol}://localhost:${server.info.port}/screenshot/empty-page.html`, renderingInfo.markup, scripts, stylesheets, config);
-          
+          const screenshotBuffer = await getScreenshot(
+            `${server.info.protocol}://localhost:${
+              server.info.port
+            }/screenshot/empty-page.html`,
+            renderingInfo.markup,
+            scripts,
+            stylesheets,
+            config
+          );
+
           const imageResponse = h.response(screenshotBuffer);
           imageResponse
-            .type('image/png')
-            .header('cache-control', cacheControlHeader);
+            .type("image/png")
+            .header("cache-control", cacheControlHeader);
           return imageResponse;
         }
       },
       {
-        path: '/screenshot/empty-page.html',
-        method: 'GET',
+        path: "/screenshot/empty-page.html",
+        method: "GET",
         handler: (request, h) => {
-          return '<!DOCTYPE html><html><head></head><body></body></html>';
+          return "<!DOCTYPE html><html><head></head><body></body></html>";
         }
       }
     ];


### PR DESCRIPTION
This passes a given `toolRuntimeConfig` query parameter in request to `/screenshot` on through `rendering-info` to the tool endpoint.

Can be used to pass config to the tool to not show interaction elements if for example `{noInteraction: true}` is given in `toolRuntimeConfig`.