### PR TITLE
Feat preview sizes

### DIFF
--- a/plugins/core/editor/index.js
+++ b/plugins/core/editor/index.js
@@ -1,33 +1,29 @@
-const Hoek = require('hoek');
-
-const routes = [
-  require('./routes/targets'),
-  require('./routes/tools'),
-  require('./routes/locales')
-]
+const Hoek = require("hoek");
 
 const defaults = {
-  editorConfig: {
-
-  }
-}
+  editorConfig: {}
+};
 
 module.exports = {
-  name: 'q-editor-api',
-  register: async function (server, options) {
+  name: "q-editor-api",
+  register: async function(server, options) {
     const settings = Hoek.applyToDefaults(defaults, options);
-    server.route(routes);
+    server.route([
+      require("./routes/targets"),
+      require("./routes/tools"),
+      require("./routes/locales").getGetRoute(settings)
+    ]);
 
     server.route({
-      path: '/editor/config',
-      method: 'GET',
+      path: "/editor/config",
+      method: "GET",
       options: {
-        description: 'Returns configuration for Q Editor',
-        tags: ['api', 'editor'],
+        description: "Returns configuration for Q Editor",
+        tags: ["api", "editor"]
       },
       handler: (request, h) => {
         return settings.editorConfig;
       }
-    })
+    });
   }
 };

--- a/plugins/core/editor/index.js
+++ b/plugins/core/editor/index.js
@@ -11,7 +11,8 @@ module.exports = {
     server.route([
       require("./routes/targets"),
       require("./routes/tools"),
-      require("./routes/locales").getGetRoute(settings)
+      require("./routes/locales").getGetToolsRoute(),
+      require("./routes/locales").getGetEditorConfigRoute(settings)
     ]);
 
     server.route({

--- a/plugins/core/editor/index.js
+++ b/plugins/core/editor/index.js
@@ -1,32 +1,33 @@
-const Hoek = require("hoek");
+const Hoek = require('hoek');
 
 const routes = [
-  require("./routes/targets"),
-  require("./routes/tools"),
-  require("./routes/locales")
-];
+  require('./routes/targets'),
+  require('./routes/tools'),
+  require('./routes/locales')
+]
 
 const defaults = {
-  editorConfig: {}
-};
+  editorConfig: {
+
+  }
+}
 
 module.exports = {
-  name: "q-editor-api",
-  register: async function(server, options) {
+  name: 'q-editor-api',
+  register: async function (server, options) {
     const settings = Hoek.applyToDefaults(defaults, options);
-    server.settings.app.editorConfig = settings.editorConfig;
     server.route(routes);
 
     server.route({
-      path: "/editor/config",
-      method: "GET",
+      path: '/editor/config',
+      method: 'GET',
       options: {
-        description: "Returns configuration for Q Editor",
-        tags: ["api", "editor"]
+        description: 'Returns configuration for Q Editor',
+        tags: ['api', 'editor'],
       },
       handler: (request, h) => {
         return settings.editorConfig;
       }
-    });
+    })
   }
 };

--- a/plugins/core/editor/index.js
+++ b/plugins/core/editor/index.js
@@ -1,33 +1,32 @@
-const Hoek = require('hoek');
+const Hoek = require("hoek");
 
 const routes = [
-  require('./routes/targets'),
-  require('./routes/tools'),
-  require('./routes/locales')
-]
+  require("./routes/targets"),
+  require("./routes/tools"),
+  require("./routes/locales")
+];
 
 const defaults = {
-  editorConfig: {
-
-  }
-}
+  editorConfig: {}
+};
 
 module.exports = {
-  name: 'q-editor-api',
-  register: async function (server, options) {
+  name: "q-editor-api",
+  register: async function(server, options) {
     const settings = Hoek.applyToDefaults(defaults, options);
+    server.settings.app.editorConfig = settings.editorConfig;
     server.route(routes);
 
     server.route({
-      path: '/editor/config',
-      method: 'GET',
+      path: "/editor/config",
+      method: "GET",
       options: {
-        description: 'Returns configuration for Q Editor',
-        tags: ['api', 'editor'],
+        description: "Returns configuration for Q Editor",
+        tags: ["api", "editor"]
       },
       handler: (request, h) => {
         return settings.editorConfig;
       }
-    })
+    });
   }
 };

--- a/plugins/core/editor/routes/locales.js
+++ b/plugins/core/editor/routes/locales.js
@@ -32,11 +32,11 @@ module.exports = {
             tool.editor.label_locales[request.params.lng];
         }
 
-        const previewSize = options.editorConfig.previewSizes;
-        if (previewSize) {
+        const previewSizes = options.editorConfig.previewSizes;
+        if (previewSizes) {
           translations.preview = {};
-          for (let previewSizeName in previewSize) {
-            const previewSize = previewSize[previewSizeName];
+          for (let previewSizeName in previewSizes) {
+            const previewSize = previewSizes[previewSizeName];
             if (
               previewSize.hasOwnProperty("label_locales") &&
               previewSize.label_locales.hasOwnProperty(request.params.lng)

--- a/plugins/core/editor/routes/locales.js
+++ b/plugins/core/editor/routes/locales.js
@@ -29,7 +29,7 @@ module.exports = {
       translations[toolName] = tool.editor.label_locales[request.params.lng];
     }
 
-    const editorConfig = request.server.settings.app.editor.get("");
+    const editorConfig = request.server.settings.app.editorConfig.get("");
     if (editorConfig.previewSizes) {
       translations.preview = {};
       for (let previewSize of previewSizes) {

--- a/plugins/core/editor/routes/locales.js
+++ b/plugins/core/editor/routes/locales.js
@@ -1,9 +1,9 @@
 const Joi = require("joi");
 
 module.exports = {
-  getGetRoute: function(options) {
+  getGetToolsRoute: function() {
     return {
-      path: "/editor/locales/{lng}/translation.json",
+      path: "/editor/tools/locales/{lng}/translation.json",
       method: "GET",
       options: {
         description: "Returns translations for given language",
@@ -31,6 +31,29 @@ module.exports = {
           translations[toolName] =
             tool.editor.label_locales[request.params.lng];
         }
+
+        return translations;
+      }
+    };
+  },
+  getGetEditorConfigRoute: function(options) {
+    return {
+      path: "/editor/locales/{lng}/translation.json",
+      method: "GET",
+      options: {
+        description: "Returns translations for given language",
+        tags: ["api", "editor", "non-critical"],
+        validate: {
+          params: {
+            lng: Joi.string().required()
+          }
+        }
+      },
+      handler: (request, h) => {
+        const tools = request.server.settings.app.tools.get("");
+
+        // compute a translation.json file for use by i18next for the given language
+        let translations = {};
 
         const previewSizes = options.editorConfig.previewSizes;
         if (previewSizes) {

--- a/plugins/core/editor/routes/locales.js
+++ b/plugins/core/editor/routes/locales.js
@@ -6,7 +6,7 @@ module.exports = {
       path: "/editor/tools/locales/{lng}/translation.json",
       method: "GET",
       options: {
-        description: "Returns translations for given language",
+        description: "Returns tool name translations for given language",
         tags: ["api", "editor", "non-critical"],
         validate: {
           params: {
@@ -41,7 +41,7 @@ module.exports = {
       path: "/editor/locales/{lng}/translation.json",
       method: "GET",
       options: {
-        description: "Returns translations for given language",
+        description: "Returns editor translations for given language",
         tags: ["api", "editor", "non-critical"],
         validate: {
           params: {
@@ -50,8 +50,6 @@ module.exports = {
         }
       },
       handler: (request, h) => {
-        const tools = request.server.settings.app.tools.get("");
-
         // compute a translation.json file for use by i18next for the given language
         let translations = {};
 

--- a/plugins/core/editor/routes/locales.js
+++ b/plugins/core/editor/routes/locales.js
@@ -32,14 +32,16 @@ module.exports = {
             tool.editor.label_locales[request.params.lng];
         }
 
-        if (options.editorConfig.previewSizes) {
+        const previewSize = options.editorConfig.previewSizes;
+        if (previewSize) {
           translations.preview = {};
-          for (let previewSize of options.editorConfig.previewSizes) {
+          for (let previewSizeName in previewSize) {
+            const previewSize = previewSize[previewSizeName];
             if (
               previewSize.hasOwnProperty("label_locales") &&
               previewSize.label_locales.hasOwnProperty(request.params.lng)
             ) {
-              translations.preview[previewSize.translationKey] =
+              translations.preview[previewSizeName] =
                 previewSize.label_locales[request.params.lng];
             }
           }

--- a/plugins/core/editor/routes/locales.js
+++ b/plugins/core/editor/routes/locales.js
@@ -1,11 +1,11 @@
-const Joi = require('joi');
+const Joi = require("joi");
 
 module.exports = {
-  path: '/editor/locales/{lng}/translation.json',
-  method: 'GET',
+  path: "/editor/locales/{lng}/translation.json",
+  method: "GET",
   options: {
-    description: 'Returns translations for given language',
-    tags: ['api', 'editor', 'non-critical'],
+    description: "Returns translations for given language",
+    tags: ["api", "editor", "non-critical"],
     validate: {
       params: {
         lng: Joi.string().required()
@@ -13,19 +13,36 @@ module.exports = {
     }
   },
   handler: (request, h) => {
-    const tools = request.server.settings.app.tools.get('');
+    const tools = request.server.settings.app.tools.get("");
 
     // compute a translation.json file for use by i18next for the given language
     // containing the tool name and it's localized label.
     let translations = {};
     for (let toolName in tools) {
       const tool = tools[toolName];
-      if (!tool.editor.hasOwnProperty('label_locales') || !tool.editor.label_locales.hasOwnProperty(request.params.lng)) {
+      if (
+        !tool.editor.hasOwnProperty("label_locales") ||
+        !tool.editor.label_locales.hasOwnProperty(request.params.lng)
+      ) {
         continue;
       }
       translations[toolName] = tool.editor.label_locales[request.params.lng];
     }
 
+    const editorConfig = request.server.settings.app.editor.get("");
+    if (editorConfig.previewSizes) {
+      translations.preview = {};
+      for (let previewSize of previewSizes) {
+        if (
+          previewSize.hasOwnProperty("label_locales") &&
+          previewSize.label_locales.hasOwnProperty(request.params.lng)
+        ) {
+          translations.preview[previewSize.translationKey] =
+            previewSize.label_locales[request.params.lng];
+        }
+      }
+    }
+
     return translations;
   }
-}
+};

--- a/plugins/core/editor/routes/locales.js
+++ b/plugins/core/editor/routes/locales.js
@@ -1,48 +1,52 @@
 const Joi = require("joi");
 
 module.exports = {
-  path: "/editor/locales/{lng}/translation.json",
-  method: "GET",
-  options: {
-    description: "Returns translations for given language",
-    tags: ["api", "editor", "non-critical"],
-    validate: {
-      params: {
-        lng: Joi.string().required()
-      }
-    }
-  },
-  handler: (request, h) => {
-    const tools = request.server.settings.app.tools.get("");
-
-    // compute a translation.json file for use by i18next for the given language
-    // containing the tool name and it's localized label.
-    let translations = {};
-    for (let toolName in tools) {
-      const tool = tools[toolName];
-      if (
-        !tool.editor.hasOwnProperty("label_locales") ||
-        !tool.editor.label_locales.hasOwnProperty(request.params.lng)
-      ) {
-        continue;
-      }
-      translations[toolName] = tool.editor.label_locales[request.params.lng];
-    }
-
-    const editorConfig = request.server.settings.app.editorConfig.get("");
-    if (editorConfig.previewSizes) {
-      translations.preview = {};
-      for (let previewSize of previewSizes) {
-        if (
-          previewSize.hasOwnProperty("label_locales") &&
-          previewSize.label_locales.hasOwnProperty(request.params.lng)
-        ) {
-          translations.preview[previewSize.translationKey] =
-            previewSize.label_locales[request.params.lng];
+  getGetRoute: function(options) {
+    return {
+      path: "/editor/locales/{lng}/translation.json",
+      method: "GET",
+      options: {
+        description: "Returns translations for given language",
+        tags: ["api", "editor", "non-critical"],
+        validate: {
+          params: {
+            lng: Joi.string().required()
+          }
         }
-      }
-    }
+      },
+      handler: (request, h) => {
+        const tools = request.server.settings.app.tools.get("");
 
-    return translations;
+        // compute a translation.json file for use by i18next for the given language
+        // containing the tool name and it's localized label.
+        let translations = {};
+        for (let toolName in tools) {
+          const tool = tools[toolName];
+          if (
+            !tool.editor.hasOwnProperty("label_locales") ||
+            !tool.editor.label_locales.hasOwnProperty(request.params.lng)
+          ) {
+            continue;
+          }
+          translations[toolName] =
+            tool.editor.label_locales[request.params.lng];
+        }
+
+        if (options.editorConfig.previewSizes) {
+          translations.preview = {};
+          for (let previewSize of options.editorConfig.previewSizes) {
+            if (
+              previewSize.hasOwnProperty("label_locales") &&
+              previewSize.label_locales.hasOwnProperty(request.params.lng)
+            ) {
+              translations.preview[previewSize.translationKey] =
+                previewSize.label_locales[request.params.lng];
+            }
+          }
+        }
+
+        return translations;
+      }
+    };
   }
 };

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -439,6 +439,24 @@ lab.experiment("core editor endpoints", () => {
 
   it("returns correctly generated translation file with tool names for given locale", async () => {
     const responseDe = await server.inject(
+      "/editor/tools/locales/de/translation.json"
+    );
+    expect(responseDe.result.tool1).to.be.equal("tool1_de");
+    expect(responseDe.result.tool2).to.be.undefined();
+
+    const responseEn = await server.inject(
+      "/editor/tools/locales/en/translation.json"
+    );
+    expect(responseEn.result.tool1).to.be.equal("tool1_en");
+
+    const responseInexistingLanguage = await server.inject(
+      "/editor/locales/inexistingLanguage/translation.json"
+    );
+    expect(responseInexistingLanguage.result.tool1).to.be.undefined();
+  });
+
+  it("returns correctly generated editor translation file for given locale", async () => {
+    const responseDe = await server.inject(
       "/editor/locales/de/translation.json"
     );
     expect(responseDe.result.tool1).to.be.equal("tool1_de");

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -455,24 +455,6 @@ lab.experiment("core editor endpoints", () => {
     expect(responseInexistingLanguage.result.tool1).to.be.undefined();
   });
 
-  it("returns correctly generated editor translation file for given locale", async () => {
-    const responseDe = await server.inject(
-      "/editor/locales/de/translation.json"
-    );
-    expect(responseDe.result.tool1).to.be.equal("tool1_de");
-    expect(responseDe.result.tool2).to.be.undefined();
-
-    const responseEn = await server.inject(
-      "/editor/locales/en/translation.json"
-    );
-    expect(responseEn.result.tool1).to.be.equal("tool1_en");
-
-    const responseInexistingLanguage = await server.inject(
-      "/editor/locales/inexistingLanguage/translation.json"
-    );
-    expect(responseInexistingLanguage.result.tool1).to.be.undefined();
-  });
-
   it("returns the tool editor configs", async () => {
     const response = await server.inject("/editor/tools");
     expect(response.result[0].name).to.be.equal("tool1");


### PR DESCRIPTION
- This PR renames the toolnames translation route from `/editor/locales/{lng}/translation.json` to `/editor/tools/locales/{lng}/translation.json`
- Keeps the old route `/editor/locales/{lng}/translation.json` for all future translations related with the editor