### PR TITLE
Remove rendering info cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "lab -a code -t 87 -c -P tests -m 3000 --verbose --leaks",
+    "test": "lab -a code -t 88 -c -P tests -m 3000 --verbose --leaks",
     "start:prod": "APP_ENV=prod node index.js",
     "start:staging": "APP_ENV=staging node index.js",
     "start:local": "APP_ENV=local node index.js"

--- a/plugins/core/base/index.js
+++ b/plugins/core/base/index.js
@@ -7,13 +7,16 @@ module.exports = {
     server.method("getCacheControlDirectivesFromConfig", async function(
       cacheControlConfig
     ) {
-      const cacheControlDirectives = ["public"];
-
-      // return early if no config given
+      // return early if no config given, default is 'no-cache'
       if (!cacheControlConfig) {
-        return cacheControlDirectives;
+        return ["no-cache"];
       }
 
+      const cacheControlDirectives = [];
+
+      if (cacheControlConfig.public) {
+        cacheControlDirectives.push("public");
+      }
       if (cacheControlConfig.maxAge) {
         cacheControlDirectives.push(`max-age=${cacheControlConfig.maxAge}`);
       }

--- a/plugins/core/base/routes/tool-default.js
+++ b/plugins/core/base/routes/tool-default.js
@@ -1,7 +1,7 @@
-const Joi = require('joi');
-const Boom = require('boom');
-const Wreck = require('wreck');
-const querystring = require('querystring');
+const Joi = require("joi");
+const Boom = require("boom");
+const Wreck = require("wreck");
+const querystring = require("querystring");
 
 async function handler(options, request, h, payload = null) {
   const tool = request.server.settings.app.tools.get(`/${request.params.tool}`);
@@ -10,18 +10,23 @@ async function handler(options, request, h, payload = null) {
     return Boom.notFound(`Tool ${request.params.tool} is not known`);
   }
 
-  let queryString = '';
+  let queryString = "";
   if (request.query && Object.keys(request.query).length > 0) {
     queryString = querystring.stringify(request.query);
   }
 
   let toolResponse;
   if (payload) {
-    toolResponse = await Wreck.post(`${tool.baseUrl}/${request.params.path}?${queryString}`, {
-      payload: payload
-    });
+    toolResponse = await Wreck.post(
+      `${tool.baseUrl}/${request.params.path}?${queryString}`,
+      {
+        payload: payload
+      }
+    );
   } else {
-    toolResponse = await Wreck.get(`${tool.baseUrl}/${request.params.path}?${queryString}`);
+    toolResponse = await Wreck.get(
+      `${tool.baseUrl}/${request.params.path}?${queryString}`
+    );
   }
 
   // prepare the response to add more headers
@@ -33,23 +38,36 @@ async function handler(options, request, h, payload = null) {
   }
 
   // add Cache-Control directives from config if we do not have no-cache set in the tool response
-  const responseCacheControl = Wreck.parseCacheControl(toolResponse.res.headers['cache-control']);
-  if (responseCacheControl['no-cache'] !== true) {
-    const configCacheControl = await request.server.methods.getCacheControlDirectivesFromConfig(options.get('/cache/cacheControl'));
-    const defaultCacheControl = Wreck.parseCacheControl(configCacheControl.join(','));
+  const responseCacheControl = Wreck.parseCacheControl(
+    toolResponse.res.headers["cache-control"]
+  );
+  if (responseCacheControl["no-cache"] !== true) {
+    const configCacheControl = await request.server.methods.getCacheControlDirectivesFromConfig(
+      options.get("/cache/cacheControl")
+    );
+    const defaultCacheControl = Wreck.parseCacheControl(
+      configCacheControl.join(",")
+    );
 
     for (directive of Object.keys(defaultCacheControl)) {
       // only add the default cache control if the directive is not present on the response from the tool
       if (!responseCacheControl.hasOwnProperty(directive)) {
-        response.header('cache-control', `${directive}=${defaultCacheControl[directive]}`, {
-          append: true
-        });
+        response.header(
+          "cache-control",
+          `${directive}=${defaultCacheControl[directive]}`,
+          {
+            append: true
+          }
+        );
       }
     }
   }
 
   // strip whitespace from cache-control header value to be consistent
-  response.header('cache-control', response.headers['cache-control'].replace(/ /g,''));
+  response.header(
+    "cache-control",
+    response.headers["cache-control"].replace(/ /g, "")
+  );
 
   return response;
 }
@@ -57,11 +75,12 @@ async function handler(options, request, h, payload = null) {
 module.exports = {
   getGetRoute: function(options) {
     return {
-      path: '/tools/{tool}/{path*}',
-      method: 'GET',
+      path: "/tools/{tool}/{path*}",
+      method: "GET",
       options: {
-        description: 'Proxies the request to the renderer service for the given tool as defined in the environment',
-        tags: ['api', 'reader-facing'],
+        description:
+          "Proxies the request to the renderer service for the given tool as defined in the environment",
+        tags: ["api", "reader-facing"],
         validate: {
           params: {
             tool: Joi.string().required(),
@@ -78,29 +97,37 @@ module.exports = {
       handler: async (request, h) => {
         let payload = null;
         if (request.query.appendItemToPayload) {
-          const item = await request.server.methods.db.item.getById(request.query.appendItemToPayload);
+          const item = await request.server.methods.db.item.getById(
+            request.query.appendItemToPayload
+          );
           payload = {
             item: item
           };
         }
-        return await Reflect.apply(handler, this, [options, request, h, payload]);
+        return await Reflect.apply(handler, this, [
+          options,
+          request,
+          h,
+          payload
+        ]);
       }
     };
   },
   getPostRoute: function(options) {
     return {
-      path: '/tools/{tool}/{path*}',
-      method: 'POST',
+      path: "/tools/{tool}/{path*}",
+      method: "POST",
       options: {
-        description: 'Proxies the request to the renderer service for the given tool as defined in the environment',
-        tags: ['api', 'reader-facing'],
+        description:
+          "Proxies the request to the renderer service for the given tool as defined in the environment",
+        tags: ["api", "reader-facing"],
         validate: {
           params: {
             tool: Joi.string().required(),
             path: Joi.string().required()
           },
           query: {
-            appendItemToPayload: Joi.string().optional(),
+            appendItemToPayload: Joi.string().optional()
           },
           payload: Joi.object(),
           options: {
@@ -108,13 +135,20 @@ module.exports = {
           }
         }
       },
-      handler:  async (request, h) => {
+      handler: async (request, h) => {
         if (request.query.appendItemToPayload) {
-          const item = await request.server.methods.db.item.getById(request.query.appendItemToPayload);
+          const item = await request.server.methods.db.item.getById(
+            request.query.appendItemToPayload
+          );
           request.payload.item = item;
         }
-        return await Reflect.apply(handler, this, [options, request, h, request.payload]);
+        return await Reflect.apply(handler, this, [
+          options,
+          request,
+          h,
+          request.payload
+        ]);
       }
-    }
+    };
   }
-}
+};

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -1,16 +1,17 @@
-const Boom = require('boom');
-const Joi = require('joi');
-const Hoek = require('hoek');
+const Boom = require("boom");
+const Joi = require("joi");
+const Hoek = require("hoek");
 
-const getRenderingInfo = require('./helpers.js').getRenderingInfo;
-const getCompiledToolRuntimeConfig = require('./helpers.js').getCompiledToolRuntimeConfig;
-const sizeValidationObject = require('./size-helpers.js').sizeValidationObject;
-const validateSize = require('./size-helpers.js').validateSize;
+const getRenderingInfo = require("./helpers.js").getRenderingInfo;
+const getCompiledToolRuntimeConfig = require("./helpers.js")
+  .getCompiledToolRuntimeConfig;
+const sizeValidationObject = require("./size-helpers.js").sizeValidationObject;
+const validateSize = require("./size-helpers.js").validateSize;
 
 function getGetRenderingInfoRoute(config) {
   return {
-    method: 'GET',
-    path: '/rendering-info/{id}/{target}',
+    method: "GET",
+    path: "/rendering-info/{id}/{target}",
     options: {
       validate: {
         params: {
@@ -28,8 +29,9 @@ function getGetRenderingInfoRoute(config) {
           allowUnknown: true
         }
       },
-      description: 'Returns rendering information for the given graphic id and target (as configured in the environment).',
-      tags: ['api', 'reader-facing']
+      description:
+        "Returns rendering information for the given graphic id and target (as configured in the environment).",
+      tags: ["api", "reader-facing"]
     },
     handler: async function(request, h) {
       let requestToolRuntimeConfig = {};
@@ -37,7 +39,7 @@ function getGetRenderingInfoRoute(config) {
       if (request.query.toolRuntimeConfig) {
         if (request.query.toolRuntimeConfig.size) {
           try {
-            validateSize(request.query.toolRuntimeConfig.size)
+            validateSize(request.query.toolRuntimeConfig.size);
           } catch (err) {
             if (err.isBoom) {
               throw err;
@@ -52,17 +54,27 @@ function getGetRenderingInfoRoute(config) {
 
       try {
         if (request.query.noCache) {
-          const renderingInfo = await request.server.methods.renderingInfo.getRenderingInfoForId(request.params.id, request.params.target, requestToolRuntimeConfig, request.query.ignoreInactive);
-          return h.response(renderingInfo)
-            .header('cache-control', 'no-cache');
+          const renderingInfo = await request.server.methods.renderingInfo.getRenderingInfoForId(
+            request.params.id,
+            request.params.target,
+            requestToolRuntimeConfig,
+            request.query.ignoreInactive
+          );
+          return h.response(renderingInfo).header("cache-control", "no-cache");
         } else {
-          const renderingInfo = await request.server.methods.renderingInfo.cached.getRenderingInfoForId(request.params.id, request.params.target, requestToolRuntimeConfig, request.query.ignoreInactive);
-          return h.response(renderingInfo)
-            .header('cache-control', config.cacheControlHeader);
+          const renderingInfo = await request.server.methods.renderingInfo.cached.getRenderingInfoForId(
+            request.params.id,
+            request.params.target,
+            requestToolRuntimeConfig,
+            request.query.ignoreInactive
+          );
+          return h
+            .response(renderingInfo)
+            .header("cache-control", config.cacheControlHeader);
         }
       } catch (err) {
         if (err.stack) {
-          request.server.log(['error'], err.stack);
+          request.server.log(["error"], err.stack);
         }
         if (err.isBoom) {
           return err;
@@ -76,8 +88,8 @@ function getGetRenderingInfoRoute(config) {
 
 function getPostRenderingInfoRoute(config) {
   return {
-    method: 'POST',
-    path: '/rendering-info/{target}',
+    method: "POST",
+    path: "/rendering-info/{target}",
     options: {
       cache: false,
       validate: {
@@ -92,10 +104,11 @@ function getPostRenderingInfoRoute(config) {
         },
         options: {
           allowUnknown: true
-        },
+        }
       },
-      description: 'Returns rendering information for the given data and target (as configured in the environment).',
-      tags: ['api', 'editor']
+      description:
+        "Returns rendering information for the given data and target (as configured in the environment).",
+      tags: ["api", "editor"]
     },
     handler: async function(request, h) {
       let requestToolRuntimeConfig = {};
@@ -103,7 +116,7 @@ function getPostRenderingInfoRoute(config) {
       if (request.query.toolRuntimeConfig) {
         if (request.query.toolRuntimeConfig.size) {
           try {
-            validateSize(request.query.toolRuntimeConfig.size)
+            validateSize(request.query.toolRuntimeConfig.size);
           } catch (err) {
             if (err.isBoom) {
               throw err;
@@ -138,70 +151,123 @@ function getPostRenderingInfoRoute(config) {
 }
 
 module.exports = {
-  name: 'q-rendering-info',
-  dependencies: 'q-base',
+  name: "q-rendering-info",
+  dependencies: "q-base",
   register: async function(server, options) {
-    Hoek.assert(server.settings.app.tools && typeof server.settings.app.tools.get === 'function', new Error('server.settings.app.tools.get needs to be a function'));    
+    Hoek.assert(
+      server.settings.app.tools &&
+        typeof server.settings.app.tools.get === "function",
+      new Error("server.settings.app.tools.get needs to be a function")
+    );
 
-    server.method('renderingInfo.getRenderingInfoForItem', async(item, target, requestToolRuntimeConfig, ignoreInactive, itemStateInDb) => {
-      const endpointConfig = server.settings.app.tools.get(`/${item.tool}/endpoint`, { target: target })
+    server.method(
+      "renderingInfo.getRenderingInfoForItem",
+      async (
+        item,
+        target,
+        requestToolRuntimeConfig,
+        ignoreInactive,
+        itemStateInDb
+      ) => {
+        const endpointConfig = server.settings.app.tools.get(
+          `/${item.tool}/endpoint`,
+          { target: target }
+        );
 
-      if (!endpointConfig) {
-        throw new Error(`no endpoint configured for tool: ${item.tool} and target: ${target}`);
+        if (!endpointConfig) {
+          throw new Error(
+            `no endpoint configured for tool: ${
+              item.tool
+            } and target: ${target}`
+          );
+        }
+
+        // compile the toolRuntimeConfig from runtimeConfig from server, tool endpoint and request
+        const toolRuntimeConfig = getCompiledToolRuntimeConfig(item, {
+          serverWideToolRuntimeConfig: options.get("/toolRuntimeConfig", {
+            target: target,
+            tool: item.tool
+          }),
+          toolEndpointConfig: endpointConfig,
+          requestToolRuntimeConfig: requestToolRuntimeConfig
+        });
+
+        const baseUrl = server.settings.app.tools.get(`/${item.tool}/baseUrl`, {
+          target: target
+        });
+
+        return await getRenderingInfo(
+          item,
+          baseUrl,
+          endpointConfig,
+          toolRuntimeConfig,
+          itemStateInDb
+        );
       }
+    );
 
-      // compile the toolRuntimeConfig from runtimeConfig from server, tool endpoint and request
-      const toolRuntimeConfig = getCompiledToolRuntimeConfig(item, {
-        serverWideToolRuntimeConfig: options.get('/toolRuntimeConfig', { target: target, tool: item.tool }),
-        toolEndpointConfig:          endpointConfig,
-        requestToolRuntimeConfig:    requestToolRuntimeConfig
-      });
+    server.method(
+      "renderingInfo.getRenderingInfoForId",
+      async (id, target, requestToolRuntimeConfig, ignoreInactive) => {
+        const item = await server.methods.db.item.getById(id, ignoreInactive);
+        // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
+        const itemStateInDb = true;
+        return server.methods.renderingInfo.getRenderingInfoForItem(
+          item,
+          target,
+          requestToolRuntimeConfig,
+          ignoreInactive,
+          itemStateInDb
+        );
+      }
+    );
 
-      const baseUrl = server.settings.app.tools.get(`/${item.tool}/baseUrl`, { target: target });
-
-      return await getRenderingInfo(item, baseUrl, endpointConfig, toolRuntimeConfig, itemStateInDb);
-    });
-
-    server.method('renderingInfo.getRenderingInfoForId', async (id, target, requestToolRuntimeConfig, ignoreInactive) => {
-      const item = await server.methods.db.item.getById(id, ignoreInactive);
-      // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
-      const itemStateInDb = true;
-      return server.methods.renderingInfo.getRenderingInfoForItem(item, target, requestToolRuntimeConfig, ignoreInactive, itemStateInDb);
-    });
-
-    server.method('renderingInfo.cached.getRenderingInfoForId', async (id, target, requestToolRuntimeConfig, ignoreInactive) => {
-      const item = await server.methods.db.item.getById(id, ignoreInactive);
-      // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
-      const itemStateInDb = true;
-      return server.methods.renderingInfo.getRenderingInfoForItem(item, target, requestToolRuntimeConfig, ignoreInactive, itemStateInDb);
-    }, {
-      cache: {
-        expiresIn: Number.isInteger(options.get('/cache/serverCacheTime')) ? options.get('/cache/serverCacheTime') : 1000,
-        generateTimeout: 10000
+    server.method(
+      "renderingInfo.cached.getRenderingInfoForId",
+      async (id, target, requestToolRuntimeConfig, ignoreInactive) => {
+        const item = await server.methods.db.item.getById(id, ignoreInactive);
+        // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
+        const itemStateInDb = true;
+        return server.methods.renderingInfo.getRenderingInfoForItem(
+          item,
+          target,
+          requestToolRuntimeConfig,
+          ignoreInactive,
+          itemStateInDb
+        );
       },
-      generateKey: (id, target, toolRuntimeConfig, ignoreInactive) => {
-        let toolRuntimeConfigKey = JSON
-          .stringify(toolRuntimeConfig)
-          .replace(new RegExp('{', 'g'), '')
-          .replace(new RegExp('}', 'g'), '')
-          .replace(new RegExp('"', 'g'), '')
-          .replace(new RegExp(':', 'g'), '-');
-        let key = `${id}-${target}-${toolRuntimeConfigKey}-${ignoreInactive}`;
-        return key;
+      {
+        cache: {
+          expiresIn: Number.isInteger(options.get("/cache/serverCacheTime"))
+            ? options.get("/cache/serverCacheTime")
+            : 1000,
+          generateTimeout: 10000
+        },
+        generateKey: (id, target, toolRuntimeConfig, ignoreInactive) => {
+          let toolRuntimeConfigKey = JSON.stringify(toolRuntimeConfig)
+            .replace(new RegExp("{", "g"), "")
+            .replace(new RegExp("}", "g"), "")
+            .replace(new RegExp('"', "g"), "")
+            .replace(new RegExp(":", "g"), "-");
+          let key = `${id}-${target}-${toolRuntimeConfigKey}-${ignoreInactive}`;
+          return key;
+        }
       }
-    });
+    );
 
     // calculate the cache control header from options given
-    const cacheControlDirectives = await server.methods.getCacheControlDirectivesFromConfig(options.get('/cache/cacheControl'));
-    const cacheControlHeader = cacheControlDirectives.join(', ');
+    const cacheControlDirectives = await server.methods.getCacheControlDirectivesFromConfig(
+      options.get("/cache/cacheControl")
+    );
+    const cacheControlHeader = cacheControlDirectives.join(", ");
 
     const routesConfig = {
       cacheControlHeader: cacheControlHeader
-    }
+    };
 
     server.route([
       getGetRenderingInfoRoute(routesConfig),
       getPostRenderingInfoRoute(routesConfig)
-    ])
+    ]);
   }
-}
+};

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -22,7 +22,8 @@ function getGetRenderingInfoRoute(config) {
           toolRuntimeConfig: Joi.object({
             size: Joi.object(sizeValidationObject).optional()
           }),
-          ignoreInactive: Joi.boolean().optional()
+          ignoreInactive: Joi.boolean().optional(),
+          noCache: Joi.boolean().optional()
         },
         options: {
           allowUnknown: true
@@ -58,7 +59,14 @@ function getGetRenderingInfoRoute(config) {
           requestToolRuntimeConfig,
           request.query.ignoreInactive
         );
-        return h.response(renderingInfo).header("cache-control", "no-cache");
+        return h
+          .response(renderingInfo)
+          .header(
+            "cache-control",
+            request.query.noCache === true
+              ? "no-cache"
+              : config.cacheControlHeader
+          );
       } catch (err) {
         if (err.stack) {
           request.server.log(["error"], err.stack);

--- a/test/config/base.js
+++ b/test/config/base.js
@@ -1,25 +1,27 @@
-const Confidence = require('confidence');
+const Confidence = require("confidence");
 
 const base = {
   cache: {
-    cacheControl: { // these are the default cache-control headers used for the tool-default route in case a tool is not responding with it's own directives.
+    cacheControl: {
+      // these are the default cache-control headers used for the tool-default route in case a tool is not responding with it's own directives.
+      public: true,
       maxAge: 1,
       sMaxAge: 1,
       staleWhileRevalidate: 1,
       staleIfError: 1
     }
   }
-}
+};
 
-const env = process.env.APP_ENV || 'local';
+const env = process.env.APP_ENV || "local";
 const store = new Confidence.Store(base);
 
 module.exports.get = (key, criteria = {}) => {
-  criteria = Object.assign({ env: env }, criteria)
-  return store.get(key, criteria)
-}
+  criteria = Object.assign({ env: env }, criteria);
+  return store.get(key, criteria);
+};
 
 module.exports.meta = (key, criteria = {}) => {
-  criteria = Object.assign({ env: env }, criteria)
-  return store.meta(key, criteria)
-}
+  criteria = Object.assign({ env: env }, criteria);
+  return store.meta(key, criteria);
+};

--- a/test/config/rendering-info.js
+++ b/test/config/rendering-info.js
@@ -1,25 +1,29 @@
-const Confidence = require('confidence');
+const Confidence = require("confidence");
 
 const renderingInfoConfig = {
   cache: {
-    cacheControl: { // these are the default cache-control headers in case a tool is not responding with it's own directives.
+    cacheControl: {
+      // these are the default cache-control headers in case a tool is not responding with it's own directives.
+      public: true,
       maxAge: {
-        $filter: 'env',
+        $filter: "env",
         local: 1,
         $default: 60
       },
       sMaxAge: {
-        $filter: 'env',
+        $filter: "env",
         local: 1,
         $default: 60
       },
-      staleWhileRevalidate: { // this is just for the CDN, it will serve maximum 24 hours old content while revalidating in the background
-        $filter: 'env',
+      staleWhileRevalidate: {
+        // this is just for the CDN, it will serve maximum 24 hours old content while revalidating in the background
+        $filter: "env",
         local: 1,
         $default: 60 * 60 * 24
       },
-      staleIfError: {  // this is just for the CDN, it will serve maximum 7 days old content if the backend is not running
-        $filter: 'env',
+      staleIfError: {
+        // this is just for the CDN, it will serve maximum 7 days old content if the backend is not running
+        $filter: "env",
         local: 1,
         $default: 60 * 60 * 24 * 7
       }
@@ -27,20 +31,20 @@ const renderingInfoConfig = {
   },
   toolRuntimeConfig: {
     foo: {
-      bar: 'baz'
+      bar: "baz"
     }
   }
-}
+};
 
-const env = process.env.APP_ENV || 'local';
+const env = process.env.APP_ENV || "local";
 const store = new Confidence.Store(renderingInfoConfig);
 
 module.exports.get = (key, criteria = {}) => {
-  criteria = Object.assign({ env: env }, criteria)
-  return store.get(key, criteria)
-}
+  criteria = Object.assign({ env: env }, criteria);
+  return store.get(key, criteria);
+};
 
 module.exports.meta = (key, criteria = {}) => {
-  criteria = Object.assign({ env: env }, criteria)
-  return store.meta(key, criteria)
-}
+  criteria = Object.assign({ env: env }, criteria);
+  return store.meta(key, criteria);
+};

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,7 +1,7 @@
 // used in screenshot plugin
 function resolvePath(resource, env) {
   if (!resource.url && resource.path) {
-    resource.url = `http://localhost:3333${resource.path}`
+    resource.url = `http://localhost:3333${resource.path}`;
   }
   delete resource.path;
   return resource;
@@ -9,48 +9,60 @@ function resolvePath(resource, env) {
 
 module.exports = [
   {
-    plugin: require('../plugins/core/base'),
-    options: require('./config/base.js')
+    plugin: require("../plugins/core/base"),
+    options: require("./config/base.js")
   },
   {
-    plugin: require('../plugins/core/db'),
+    plugin: require("../plugins/core/db"),
     options: {
-      protocol: 'http',
-      host: 'localhost:5984',
-      database: 'q-items'
+      protocol: "http",
+      host: "localhost:5984",
+      database: "q-items"
     }
   },
   {
-    plugin: require('../plugins/core/editor'),
+    plugin: require("../plugins/core/editor"),
     options: {
-      editorConfig: require('./config/editor.js').get('')
+      editorConfig: require("./config/editor.js").get("")
     }
   },
   {
-    plugin: require('../plugins/core/rendering-info'),
-    options: require('./config/rendering-info.js')
+    plugin: require("../plugins/core/rendering-info"),
+    options: require("./config/rendering-info.js")
   },
   {
-    plugin: require('../plugins/fixtures')
+    plugin: require("../plugins/fixtures")
   },
   {
-    plugin: require('../plugins/statistics')
+    plugin: require("../plugins/statistics")
   },
   {
-    plugin: require('../plugins/screenshot'),
+    plugin: require("../plugins/screenshot"),
     options: {
       getScripts: function(renderingInfo) {
         const scripts = [];
-        if (renderingInfo.loaderConfig && renderingInfo.loaderConfig.loadSystemJs === 'full') {
-          scripts.push({url: `${process.env.Q_SERVER_BASE_URL}/files/system.js`});
+        if (
+          renderingInfo.loaderConfig &&
+          renderingInfo.loaderConfig.loadSystemJs === "full"
+        ) {
+          scripts.push({
+            url: `${process.env.Q_SERVER_BASE_URL}/files/system.js`
+          });
         }
-        if (renderingInfo.loaderConfig && renderingInfo.loaderConfig.polyfills) {
-          scripts.push({url: `https://cdn.polyfill.io/v2/polyfill.min.js?features=${renderingInfo.loaderConfig.polyfills.join(',')}`});
+        if (
+          renderingInfo.loaderConfig &&
+          renderingInfo.loaderConfig.polyfills
+        ) {
+          scripts.push({
+            url: `https://cdn.polyfill.io/v2/polyfill.min.js?features=${renderingInfo.loaderConfig.polyfills.join(
+              ","
+            )}`
+          });
         }
         if (renderingInfo.scripts && Array.isArray(renderingInfo.scripts)) {
           for (let script of renderingInfo.scripts) {
             script = resolvePath(script);
-            if (script.url && script.url.includes('track-manager')) {
+            if (script.url && script.url.includes("track-manager")) {
               continue;
             }
             scripts.push(script);
@@ -60,7 +72,10 @@ module.exports = [
       },
       getStylesheets: function(renderingInfo) {
         const stylesheets = [];
-        if (renderingInfo.stylesheets && Array.isArray(renderingInfo.stylesheets)) {
+        if (
+          renderingInfo.stylesheets &&
+          Array.isArray(renderingInfo.stylesheets)
+        ) {
           for (let stylesheet of renderingInfo.stylesheets) {
             stylesheet = resolvePath(stylesheet);
             stylesheets.push(stylesheet);
@@ -70,6 +85,7 @@ module.exports = [
       },
       cache: {
         cacheControl: {
+          public: true,
           maxAge: 1,
           sMaxAge: 1,
           staleWhileRevalidate: 1,
@@ -79,10 +95,10 @@ module.exports = [
     }
   },
   {
-    plugin: require('../plugins/cdn/keycdn'),
+    plugin: require("../plugins/cdn/keycdn"),
     options: {
-      zoneId: 'some-zone-id',
-      apiKey: 'some-api-key',
+      zoneId: "some-zone-id",
+      apiKey: "some-api-key",
       dryRun: true
     }
   }

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -1,25 +1,24 @@
-const Lab = require('lab');
-const Code = require('code');
-const Hapi = require('hapi');
-const lab = exports.lab = Lab.script();
+const Lab = require("lab");
+const Code = require("code");
+const Hapi = require("hapi");
+const lab = (exports.lab = Lab.script());
 
-const clone = require('clone');
+const clone = require("clone");
 
 const expect = Code.expect;
 const before = lab.before;
 const after = lab.after;
 const it = lab.it;
 
-const items = require('./mock/items.js');
-const plugins = require('./plugins.js');
-let server = require('./server.js').getServer();
+const items = require("./mock/items.js");
+const plugins = require("./plugins.js");
+let server = require("./server.js").getServer();
 
 before(async () => {
   try {
     await server.register(plugins);
     await server.start();
-  }
-  catch (err) {
+  } catch (err) {
     expect(err).to.not.exist();
   }
 });
@@ -29,154 +28,179 @@ after(async () => {
   server = null;
 });
 
-lab.experiment('meta-properties', () => {
-
-  const deleteMetaProperties = require('../helper/meta-properties').deleteMetaProperties;
-  it('strips meta properties', () => {
+lab.experiment("meta-properties", () => {
+  const deleteMetaProperties = require("../helper/meta-properties")
+    .deleteMetaProperties;
+  it("strips meta properties", () => {
     let slimItem = deleteMetaProperties(clone(items[0]));
     expect(slimItem.editedBy).to.be.undefined();
     expect(slimItem.createdBy).to.be.undefined();
     expect(slimItem.department).to.be.undefined();
-  })
+  });
 
-  it('should only delete all meta properties', function() {
+  it("should only delete all meta properties", function() {
     let slimItem = deleteMetaProperties(clone(items[0]));
     expect(slimItem.data).to.not.be.undefined();
-  })
-
+  });
 });
 
-lab.experiment('server.method: getCacheControlDirectivesFromConfig', () => {
-  it('returns Cache-Control: public if no config given', async () => {
+lab.experiment("server.method: getCacheControlDirectivesFromConfig", () => {
+  it("returns Cache-Control: public if no config given", async () => {
     const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig();
-    expect(configCacheControl[0]).to.be.equal('public');
+    expect(configCacheControl[0]).to.be.equal("no-cache");
   });
 
-  it('returns correct cache control header if maxAge given', async () => {
-    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig({
-      maxAge: 1
-    });
-    expect(configCacheControl[0]).to.be.equal('public');
-    expect(configCacheControl[1]).to.be.equal('max-age=1');
+  it("returns correct cache control header if maxAge given", async () => {
+    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig(
+      {
+        public: true,
+        maxAge: 1
+      }
+    );
+    expect(configCacheControl[0]).to.be.equal("public");
+    expect(configCacheControl[1]).to.be.equal("max-age=1");
   });
 
-  it('returns correct cache control header if sMaxAge given', async () => {
-    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig({
-      sMaxAge: 1
-    });
-    expect(configCacheControl[0]).to.be.equal('public');
-    expect(configCacheControl[1]).to.be.equal('s-maxage=1');
+  it("returns correct cache control header if sMaxAge given", async () => {
+    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig(
+      {
+        sMaxAge: 1
+      }
+    );
+    expect(configCacheControl[0]).to.be.equal("s-maxage=1");
   });
 
-  it('returns correct cache control header if staleWhileRevalidate given', async () => {
-    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig({
-      staleWhileRevalidate: 1
-    });
-    expect(configCacheControl[0]).to.be.equal('public');
-    expect(configCacheControl[1]).to.be.equal('stale-while-revalidate=1');
+  it("returns correct cache control header if staleWhileRevalidate given", async () => {
+    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig(
+      {
+        public: true,
+        staleWhileRevalidate: 1
+      }
+    );
+    expect(configCacheControl[0]).to.be.equal("public");
+    expect(configCacheControl[1]).to.be.equal("stale-while-revalidate=1");
   });
 
-  it('returns correct cache control header if staleIfError given', async () => {
-    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig({
-      staleIfError: 1
-    });
-    expect(configCacheControl[0]).to.be.equal('public');
-    expect(configCacheControl[1]).to.be.equal('stale-if-error=1');
-  });
-  
-  it('computes correct cache control headers if all config given', async () => {
-    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig(require('./config/base.js').get('/cache/cacheControl'));
-    expect(configCacheControl[0]).to.be.equal('public');
-    expect(configCacheControl[1]).to.be.equal('max-age=1');
-    expect(configCacheControl[2]).to.be.equal('s-maxage=1');
-    expect(configCacheControl[3]).to.be.equal('stale-while-revalidate=1');
-    expect(configCacheControl[4]).to.be.equal('stale-if-error=1');
+  it("returns correct cache control header if staleIfError given", async () => {
+    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig(
+      {
+        public: true,
+        staleIfError: 1
+      }
+    );
+    expect(configCacheControl[0]).to.be.equal("public");
+    expect(configCacheControl[1]).to.be.equal("stale-if-error=1");
   });
 
+  it("computes correct cache control headers if all config given", async () => {
+    const configCacheControl = await server.methods.getCacheControlDirectivesFromConfig(
+      require("./config/base.js").get("/cache/cacheControl")
+    );
+    expect(configCacheControl[0]).to.be.equal("public");
+    expect(configCacheControl[1]).to.be.equal("max-age=1");
+    expect(configCacheControl[2]).to.be.equal("s-maxage=1");
+    expect(configCacheControl[3]).to.be.equal("stale-while-revalidate=1");
+    expect(configCacheControl[4]).to.be.equal("stale-if-error=1");
+  });
 });
 
-lab.experiment('rendering-info toolRuntimeConfig', () => {
-  it('constructs correct default toolBaseUrl if no path given', async () => {
-    const getCompiledToolRuntimeConfig = require('../plugins/core/rendering-info/helpers.js').getCompiledToolRuntimeConfig;
+lab.experiment("rendering-info toolRuntimeConfig", () => {
+  it("constructs correct default toolBaseUrl if no path given", async () => {
+    const getCompiledToolRuntimeConfig = require("../plugins/core/rendering-info/helpers.js")
+      .getCompiledToolRuntimeConfig;
     const toolRuntimeConfig = getCompiledToolRuntimeConfig(clone(items[0]), {
       serverWideToolRuntimeConfig: {
         toolBaseUrl: {
-          protocol: 'https',
-          host: 'q-server-host'
+          protocol: "https",
+          host: "q-server-host"
         }
       }
     });
 
-    expect(toolRuntimeConfig.toolBaseUrl).to.be.equal('https://q-server-host/tools/tool1');
+    expect(toolRuntimeConfig.toolBaseUrl).to.be.equal(
+      "https://q-server-host/tools/tool1"
+    );
   });
 
-  it('constructs correct toolBaseUrl if path given', async () => {
-    const getCompiledToolRuntimeConfig = require('../plugins/core/rendering-info/helpers.js').getCompiledToolRuntimeConfig;
+  it("constructs correct toolBaseUrl if path given", async () => {
+    const getCompiledToolRuntimeConfig = require("../plugins/core/rendering-info/helpers.js")
+      .getCompiledToolRuntimeConfig;
     const toolRuntimeConfig = getCompiledToolRuntimeConfig(clone(items[0]), {
       serverWideToolRuntimeConfig: {
         toolBaseUrl: {
-          protocol: 'https',
-          host: 'q-server-host',
-          path: '/some-other/path'
+          protocol: "https",
+          host: "q-server-host",
+          path: "/some-other/path"
         }
       }
     });
-    expect(toolRuntimeConfig.toolBaseUrl).to.be.equal('https://q-server-host/some-other/path');
+    expect(toolRuntimeConfig.toolBaseUrl).to.be.equal(
+      "https://q-server-host/some-other/path"
+    );
   });
 
-  it('applies toolEndpointConfig if given', async () => {
-    const getCompiledToolRuntimeConfig = require('../plugins/core/rendering-info/helpers.js').getCompiledToolRuntimeConfig;
+  it("applies toolEndpointConfig if given", async () => {
+    const getCompiledToolRuntimeConfig = require("../plugins/core/rendering-info/helpers.js")
+      .getCompiledToolRuntimeConfig;
     const toolRuntimeConfig = getCompiledToolRuntimeConfig(clone(items[0]), {
       serverWideToolRuntimeConfig: {
-        foo: 'server'
+        foo: "server"
       },
       toolEndpointConfig: {
         toolRuntimeConfig: {
-          foo: 'toolendpoint'
+          foo: "toolendpoint"
         }
       }
     });
-    expect(toolRuntimeConfig.foo).to.be.equal('toolendpoint');
+    expect(toolRuntimeConfig.foo).to.be.equal("toolendpoint");
   });
 
-  it('applies toolEndpointConfig and requestToolRuntimeConfig if given', { plan: 2 }, async () => {
-    const getCompiledToolRuntimeConfig = require('../plugins/core/rendering-info/helpers.js').getCompiledToolRuntimeConfig;
-    const toolRuntimeConfig = getCompiledToolRuntimeConfig(clone(items[0]), {
-      serverWideToolRuntimeConfig: {
-        foo: 'server',
-      },
-      toolEndpointConfig: {
-        toolRuntimeConfig: {
-          foo: 'toolendpoint',
-          bar: 'toolendpoint'
+  it(
+    "applies toolEndpointConfig and requestToolRuntimeConfig if given",
+    { plan: 2 },
+    async () => {
+      const getCompiledToolRuntimeConfig = require("../plugins/core/rendering-info/helpers.js")
+        .getCompiledToolRuntimeConfig;
+      const toolRuntimeConfig = getCompiledToolRuntimeConfig(clone(items[0]), {
+        serverWideToolRuntimeConfig: {
+          foo: "server"
+        },
+        toolEndpointConfig: {
+          toolRuntimeConfig: {
+            foo: "toolendpoint",
+            bar: "toolendpoint"
+          }
+        },
+        requestToolRuntimeConfig: {
+          bar: "request"
         }
-      },
-      requestToolRuntimeConfig: {
-        bar: 'request'
-      }
-    });
-    expect(toolRuntimeConfig.foo).to.be.equal('toolendpoint');
-    expect(toolRuntimeConfig.bar).to.be.equal('request');
-  });
+      });
+      expect(toolRuntimeConfig.foo).to.be.equal("toolendpoint");
+      expect(toolRuntimeConfig.bar).to.be.equal("request");
+    }
+  );
 
-  it('fails to validate invalid size object', { plan: 10 }, async () => {
-    const validateSize = require('../plugins/core/rendering-info/size-helpers.js').validateSize;
+  it("fails to validate invalid size object", { plan: 10 }, async () => {
+    const validateSize = require("../plugins/core/rendering-info/size-helpers.js")
+      .validateSize;
     try {
       validateSize({
         width: [
           {
             value: 500,
-            comparison: '>'
+            comparison: ">"
           },
           {
             value: 400,
-            comparison: '<'
+            comparison: "<"
           }
         ]
       });
     } catch (err) {
       expect(err).to.be.an.instanceof(Error);
-      expect(err.message).to.be.equal('The combination of values and comparison signs does not result in a meaningful range.');
+      expect(err.message).to.be.equal(
+        "The combination of values and comparison signs does not result in a meaningful range."
+      );
     }
 
     try {
@@ -184,17 +208,19 @@ lab.experiment('rendering-info toolRuntimeConfig', () => {
         width: [
           {
             value: 100,
-            comparison: '='
+            comparison: "="
           },
           {
             value: 200,
-            comparison: '<'
+            comparison: "<"
           }
         ]
       });
     } catch (err) {
       expect(err).to.be.an.instanceof(Error);
-      expect(err.message).to.be.equal('The combination of values and comparison signs does not result in a meaningful range.');
+      expect(err.message).to.be.equal(
+        "The combination of values and comparison signs does not result in a meaningful range."
+      );
     }
 
     try {
@@ -202,17 +228,19 @@ lab.experiment('rendering-info toolRuntimeConfig', () => {
         width: [
           {
             value: 100,
-            comparison: '>'
+            comparison: ">"
           },
           {
             value: 200,
-            comparison: '='
+            comparison: "="
           }
         ]
       });
     } catch (err) {
       expect(err).to.be.an.instanceof(Error);
-      expect(err.message).to.be.equal('The combination of values and comparison signs does not result in a meaningful range.');
+      expect(err.message).to.be.equal(
+        "The combination of values and comparison signs does not result in a meaningful range."
+      );
     }
 
     try {
@@ -220,19 +248,21 @@ lab.experiment('rendering-info toolRuntimeConfig', () => {
         width: [
           {
             value: 200,
-            comparison: '>',
-            unit: 'px'
+            comparison: ">",
+            unit: "px"
           },
           {
             value: 300,
-            comparison: '<',
-            unit: 'cm'
+            comparison: "<",
+            unit: "cm"
           }
         ]
       });
     } catch (err) {
       expect(err).to.be.an.instanceof(Error);
-      expect(err.message).to.be.equal('Units are not the same for the given range.');
+      expect(err.message).to.be.equal(
+        "Units are not the same for the given range."
+      );
     }
 
     try {
@@ -240,33 +270,36 @@ lab.experiment('rendering-info toolRuntimeConfig', () => {
         width: [
           {
             value: 200,
-            comparison: '>',
+            comparison: ">"
           },
           {
             value: 300,
-            comparison: '>',
+            comparison: ">"
           }
         ]
       });
     } catch (err) {
       expect(err).to.be.an.instanceof(Error);
-      expect(err.message).to.be.equal('The combination of values and comparison signs does not result in a meaningful range.');
+      expect(err.message).to.be.equal(
+        "The combination of values and comparison signs does not result in a meaningful range."
+      );
     }
   });
 
-  it('validates valid size object', { plan: 2 }, async () => {
-    const validateSize = require('../plugins/core/rendering-info/size-helpers.js').validateSize;
+  it("validates valid size object", { plan: 2 }, async () => {
+    const validateSize = require("../plugins/core/rendering-info/size-helpers.js")
+      .validateSize;
     let error;
     try {
       validateSize({
         width: [
           {
             value: 500,
-            comparison: '>'
+            comparison: ">"
           },
           {
             value: 800,
-            comparison: '<'
+            comparison: "<"
           }
         ]
       });
@@ -281,7 +314,7 @@ lab.experiment('rendering-info toolRuntimeConfig', () => {
         width: [
           {
             value: 200,
-            comparison: '='
+            comparison: "="
           }
         ]
       });
@@ -290,5 +323,4 @@ lab.experiment('rendering-info toolRuntimeConfig', () => {
     }
     expect(error).to.be.undefined();
   });
-
 });


### PR DESCRIPTION
- This removes the server side caching of rendering info sent from the tool to Q server
- This is done to eliminate the problem where the client side scripts fail for some of our tools if the same graphic is embedded twice
- A setup where the Q loader is built on the server side and the caching of a complete site happens after that, this is not a problem
- If the Q loader is built in the client, it should use a CDN for caching in front of Q server anyway and could detect the case where the same graphic is embedded twice and then solve this problem by adding a random query parameter or something like that.
- the `public` cache control directive is not added per default but needs to be in the config (this is BC breaking)