### PR TITLE
Get inactive or active items in path route

### DIFF
--- a/plugins/core/base/routes/tool-default.js
+++ b/plugins/core/base/routes/tool-default.js
@@ -97,8 +97,10 @@ module.exports = {
       handler: async (request, h) => {
         let payload = null;
         if (request.query.appendItemToPayload) {
+          // Get item with ignoreInactive set to true (gets inactive or active item)
           const item = await request.server.methods.db.item.getById(
-            request.query.appendItemToPayload
+            request.query.appendItemToPayload,
+            true
           );
           payload = {
             item: item
@@ -137,8 +139,10 @@ module.exports = {
       },
       handler: async (request, h) => {
         if (request.query.appendItemToPayload) {
+          // Get item with ignoreInactive set to true (gets inactive or active item)
           const item = await request.server.methods.db.item.getById(
-            request.query.appendItemToPayload
+            request.query.appendItemToPayload,
+            true
           );
           request.payload.item = item;
         }

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -362,21 +362,21 @@ lab.experiment("core tool proxy routes", () => {
     expect(response.result).to.be.equal("mock-item-active");
   });
 
-  it("fails with 403 if the item id passed as appendItemToPayload is inactive for GET requests", async () => {
+  it("passes the item from db in the payload of the tool request if query appendItemToPayload is set to an id of an inactive item for GET requests", async () => {
     const response = await server.inject(
       "/tools/tool1/endpoint-returning-the-id-from-tool-in-payload?appendItemToPayload=mock-item-inactive"
     );
-    expect(response.statusCode).to.be.equal(403);
+    expect(response.result).to.be.equal("mock-item-inactive");
   });
 
-  it("fails with 403 if the item id passed as appendItemToPayload is inactive for POST requests", async () => {
+  it("passes the item from db in the payload of the tool request if query appendItemToPayload is set to an id of an inactive item for POST requests", async () => {
     const response = await server.inject({
       url:
         "/tools/tool1/endpoint-returning-the-id-from-tool-in-payload?appendItemToPayload=mock-item-inactive",
       method: "POST",
       payload: {}
     });
-    expect(response.statusCode).to.be.equal(403);
+    expect(response.result).to.be.equal("mock-item-inactive");
   });
 
   it("fails with 404 if the item id passed as appendItemToPayload is not found for GET requests", async () => {


### PR DESCRIPTION
- This PR adds ignoreInactive property to getById method in get and post path-routes. This will get active or inactive items