### PR TITLE
Feat get files

### DIFF
--- a/plugins/core/rendering-info/helpers.js
+++ b/plugins/core/rendering-info/helpers.js
@@ -161,6 +161,26 @@ function getCompiledToolRuntimeConfig(
     }${path}`;
   }
 
+  // simplify the fileRequestBaseUrl to an url string if it is an object by applying some defaults before sending it to the tool
+  if (
+    typeof overallToolRuntimeConfig.fileRequestBaseUrl === "object" &&
+    overallToolRuntimeConfig.fileRequestBaseUrl.host
+  ) {
+    // the default protocol is https
+    let protocol = "https";
+    if (overallToolRuntimeConfig.fileRequestBaseUrl.protocol) {
+      protocol = overallToolRuntimeConfig.fileRequestBaseUrl.protocol;
+    }
+    // the default if no path is given is /file
+    let path = "/file";
+    if (overallToolRuntimeConfig.fileRequestBaseUrl.path) {
+      path = overallToolRuntimeConfig.fileRequestBaseUrl.path;
+    }
+    overallToolRuntimeConfig.fileRequestBaseUrl = `${protocol}://${
+      overallToolRuntimeConfig.fileRequestBaseUrl.host
+    }${path}`;
+  }
+
   // default to the overall config
   let toolRuntimeConfig = overallToolRuntimeConfig;
 

--- a/plugins/file/index.js
+++ b/plugins/file/index.js
@@ -134,5 +134,28 @@ module.exports = {
         };
       }
     });
+
+    server.route({
+      method: "GET",
+      path: "/file/{fileKey*}",
+      options: {
+        tags: ["api"]
+      },
+      handler: async function(request, h) {
+        return h
+          .response(
+            s3
+              .getObject({
+                Bucket: options.s3Bucket,
+                Key: request.params.fileKey
+              })
+              .createReadStream()
+          )
+          .header(
+            "cache-control",
+            "max-age=31536000, s-maxage=31536000, stale-while-revalidate=31536000, stale-if-error=31536000, immutable"
+          );
+      }
+    });
   }
 };


### PR DESCRIPTION
- this introduces a new toolRuntimeConfig variable `fileRequestBaseUrl` which should point to the GET /file endpoint.
- this variable can be set in the toolRuntimeConfig for the whole server like here: https://github.com/nzzdev/Q-server-nzz/blob/dev/config/nzz/rendering-info.js#L38-L42 but also for in the tool config if one wants to do that.
- one GET /file endpoint is implemented in the file plugin, but using this configuration one could also implement another handler for this to do something special.
- GET /file sets immutable cache control header as we hash the file content during upload and put the hash in the filename