### PR TITLE
Normalize all content-types containing javascript to text/javascript

### DIFF
--- a/plugins/file/index.js
+++ b/plugins/file/index.js
@@ -75,7 +75,10 @@ module.exports = {
           return Boom.badData("Failed to read file");
         }
 
-        const contentType = file.hapi.headers["content-type"];
+        let contentType = file.hapi.headers["content-type"];
+        if (contentType.includes("javascript")) {
+          contentType = "text/javascript";
+        }
         if (contentTypes.indexOf(contentType) === -1) {
           return Boom.unsupportedMediaType("Content-type not allowed");
         }

--- a/plugins/file/index.js
+++ b/plugins/file/index.js
@@ -76,9 +76,13 @@ module.exports = {
         }
 
         let contentType = file.hapi.headers["content-type"];
+        // The HTML spec (https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages) defines
+        // that servers should only use content-type text/javascript for js resources.
+        // Therefore we normalize all content-types containing the string javascript to text/javascript
         if (contentType.includes("javascript")) {
           contentType = "text/javascript";
         }
+
         if (contentTypes.indexOf(contentType) === -1) {
           return Boom.unsupportedMediaType("Content-type not allowed");
         }


### PR DESCRIPTION
- The [HTML spec](https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages) defines, that servers should only use mime-type `text/javascript` for javascript resources
- This PR implements normalization for all content-types containing the string javascript to the content-type `text/javascript`
- See als to PR in files plugin in q-server (which changes the accepted content-type for javascript resources to text/javascript)-> https://github.com/nzzdev/Q-server-nzz/pull/173