### PR TITLE
Get file extension based on content-type application/javascript

### DIFF
--- a/plugins/file/index.js
+++ b/plugins/file/index.js
@@ -88,7 +88,7 @@ module.exports = {
         }
 
         // The mimos package doesn't store the extension for the content-type text/javascript
-        // because its marked as depricated by IANA. Therefore we get the file extension based
+        // because its marked as deprecated by IANA. Therefore we get the file extension based
         // on the content-type application/javascript
         let type;
         if (contentType === "text/javascript") {

--- a/plugins/file/index.js
+++ b/plugins/file/index.js
@@ -90,11 +90,9 @@ module.exports = {
         // The mimos package doesn't store the extension for the content-type text/javascript
         // because its marked as deprecated by IANA. Therefore we get the file extension based
         // on the content-type application/javascript
-        let type;
+        let type = mimos.type(contentType);
         if (contentType === "text/javascript") {
           type = mimos.type("application/javascript");
-        } else {
-          type = mimos.type(contentType);
         }
         const extension = type.extensions[0] || "";
 

--- a/plugins/file/index.js
+++ b/plugins/file/index.js
@@ -88,8 +88,8 @@ module.exports = {
         }
 
         // The mimos package doesn't store the extension for the content-type text/javascript
-        // because its marked as depricated by IANA. Therefore we get the mimos type based on the
-        // content-type application/javascript
+        // because its marked as depricated by IANA. Therefore we get the file extension based
+        // on the content-type application/javascript
         let type;
         if (contentType === "text/javascript") {
           type = mimos.type("application/javascript");

--- a/plugins/file/index.js
+++ b/plugins/file/index.js
@@ -87,10 +87,10 @@ module.exports = {
           return Boom.unsupportedMediaType("Content-type not allowed");
         }
 
+        let type = mimos.type(contentType);
         // The mimos package doesn't store the extension for the content-type text/javascript
         // because its marked as deprecated by IANA. Therefore we get the file extension based
         // on the content-type application/javascript
-        let type = mimos.type(contentType);
         if (contentType === "text/javascript") {
           type = mimos.type("application/javascript");
         }

--- a/plugins/file/index.js
+++ b/plugins/file/index.js
@@ -87,7 +87,15 @@ module.exports = {
           return Boom.unsupportedMediaType("Content-type not allowed");
         }
 
-        const type = mimos.type(contentType);
+        // The mimos package doesn't store the extension for the content-type text/javascript
+        // because its marked as depricated by IANA. Therefore we get the mimos type based on the
+        // content-type application/javascript
+        let type;
+        if (contentType === "text/javascript") {
+          type = mimos.type("application/javascript");
+        } else {
+          type = mimos.type(contentType);
+        }
         const extension = type.extensions[0] || "";
 
         // buffer the contents to hash and later upload to s3


### PR DESCRIPTION
- The mimos package doesn't store the file extension for content-type `text/javascript`, because IANA marks this content-type as depricated. See [this issue](https://github.com/jshttp/mime-db/issues/112) for more details.
- Therefore I propose to get the file extension based on content-type `application/javascript`