### PR TITLE
Feat append item to payload for schema

### DIFF
--- a/plugins/core/base/index.js
+++ b/plugins/core/base/index.js
@@ -1,10 +1,12 @@
+const getToolResponse = require("./methods/getToolResponse.js").getToolResponse;
+
 module.exports = {
   name: "q-base",
   dependencies: ["q-db"],
-  register: async function(server, options) {
+  register: async function (server, options) {
     await server.register([require("vision"), require("inert")]);
-
-    server.method("getCacheControlDirectivesFromConfig", async function(
+    server.method("getToolResponse", getToolResponse);
+    server.method("getCacheControlDirectivesFromConfig", async function (
       cacheControlConfig
     ) {
       // return early if no config given, default is 'no-cache'
@@ -50,8 +52,8 @@ module.exports = {
       require("./routes/search.js"),
       require("./routes/tool-default.js").getGetRoute(options),
       require("./routes/tool-default.js").getPostRoute(options),
-      require("./routes/tool-schema.js").schema,
-      require("./routes/tool-schema.js").displayOptionsSchema,
+      require("./routes/tool-schema.js").getSchema(options),
+      require("./routes/tool-schema.js").getDisplayOptionsSchema(options),
       require("./routes/health.js"),
       require("./routes/version.js"),
       require("./routes/admin/migration.js")

--- a/plugins/core/base/index.js
+++ b/plugins/core/base/index.js
@@ -1,4 +1,5 @@
 const getToolResponse = require("./methods/getToolResponse.js").getToolResponse;
+const getCacheControlDirectivesFromConfig = require("./methods/getCacheControlDirectivesFromConfig.js").getCacheControlDirectivesFromConfig;
 
 module.exports = {
   name: "q-base",
@@ -6,38 +7,7 @@ module.exports = {
   register: async function (server, options) {
     await server.register([require("vision"), require("inert")]);
     server.method("getToolResponse", getToolResponse);
-    server.method("getCacheControlDirectivesFromConfig", async function (
-      cacheControlConfig
-    ) {
-      // return early if no config given, default is 'no-cache'
-      if (!cacheControlConfig) {
-        return ["no-cache"];
-      }
-
-      const cacheControlDirectives = [];
-
-      if (cacheControlConfig.public) {
-        cacheControlDirectives.push("public");
-      }
-      if (cacheControlConfig.maxAge) {
-        cacheControlDirectives.push(`max-age=${cacheControlConfig.maxAge}`);
-      }
-      if (cacheControlConfig.sMaxAge) {
-        cacheControlDirectives.push(`s-maxage=${cacheControlConfig.sMaxAge}`);
-      }
-      if (cacheControlConfig.staleWhileRevalidate) {
-        cacheControlDirectives.push(
-          `stale-while-revalidate=${cacheControlConfig.staleWhileRevalidate}`
-        );
-      }
-      if (cacheControlConfig.staleIfError) {
-        cacheControlDirectives.push(
-          `stale-if-error=${cacheControlConfig.staleIfError}`
-        );
-      }
-
-      return cacheControlDirectives;
-    });
+    server.method("getCacheControlDirectivesFromConfig", getCacheControlDirectivesFromConfig);
 
     server.event("item.new");
     server.event("item.update");

--- a/plugins/core/base/methods/getCacheControlDirectivesFromConfig.js
+++ b/plugins/core/base/methods/getCacheControlDirectivesFromConfig.js
@@ -1,0 +1,30 @@
+exports.getCacheControlDirectivesFromConfig = async function (cacheControlConfig) {
+  // return early if no config given, default is 'no-cache'
+  if (!cacheControlConfig) {
+    return ["no-cache"];
+  }
+
+  const cacheControlDirectives = [];
+
+  if (cacheControlConfig.public) {
+    cacheControlDirectives.push("public");
+  }
+  if (cacheControlConfig.maxAge) {
+    cacheControlDirectives.push(`max-age=${cacheControlConfig.maxAge}`);
+  }
+  if (cacheControlConfig.sMaxAge) {
+    cacheControlDirectives.push(`s-maxage=${cacheControlConfig.sMaxAge}`);
+  }
+  if (cacheControlConfig.staleWhileRevalidate) {
+    cacheControlDirectives.push(
+      `stale-while-revalidate=${cacheControlConfig.staleWhileRevalidate}`
+    );
+  }
+  if (cacheControlConfig.staleIfError) {
+    cacheControlDirectives.push(
+      `stale-if-error=${cacheControlConfig.staleIfError}`
+    );
+  }
+
+  return cacheControlDirectives;
+}

--- a/plugins/core/base/methods/getToolResponse.js
+++ b/plugins/core/base/methods/getToolResponse.js
@@ -1,0 +1,87 @@
+const Boom = require("boom");
+const Wreck = require("wreck");
+const querystring = require("querystring");
+
+exports.getToolResponse = async function (options, request, h) {
+  if (request.query.appendItemToPayload) {
+    // Get item with ignoreInactive set to true (gets inactive or active item)
+    const item = await request.server.methods.db.item.getById(
+      request.query.appendItemToPayload,
+      true
+    );
+    if (request.payload) {
+      request.payload.item = item;
+    } else {
+      request.payload = {
+        item: item
+      }
+    }
+
+  }
+  const tool = request.server.settings.app.tools.get(`/${request.params.tool}`);
+
+  if (!tool) {
+    return Boom.notFound(`Tool ${request.params.tool} is not known`);
+  }
+
+  let queryString = "";
+  if (request.query && Object.keys(request.query).length > 0) {
+    queryString = querystring.stringify(request.query);
+  }
+
+  let toolResponse;
+  if (request.payload) {
+    toolResponse = await Wreck.post(
+      `${tool.baseUrl}/${request.params.path}?${queryString}`,
+      {
+        payload: request.payload
+      }
+    );
+  } else {
+    toolResponse = await Wreck.get(
+      `${tool.baseUrl}/${request.params.path}?${queryString}`
+    );
+  }
+
+  // prepare the response to add more headers
+  const response = h.response(toolResponse.payload);
+
+  // set all the headers from the tool response
+  for (let header in toolResponse.res.headers) {
+    response.header(header, toolResponse.res.headers[header]);
+  }
+
+  // add Cache-Control directives from config if we do not have no-cache set in the tool response
+  const responseCacheControl = Wreck.parseCacheControl(
+    toolResponse.res.headers["cache-control"]
+  );
+  if (responseCacheControl["no-cache"] !== true) {
+    const configCacheControl = await request.server.methods.getCacheControlDirectivesFromConfig(
+      options.get("/cache/cacheControl")
+    );
+    const defaultCacheControl = Wreck.parseCacheControl(
+      configCacheControl.join(",")
+    );
+
+    for (directive of Object.keys(defaultCacheControl)) {
+      // only add the default cache control if the directive is not present on the response from the tool
+      if (!responseCacheControl.hasOwnProperty(directive)) {
+        response.header(
+          "cache-control",
+          `${directive}=${defaultCacheControl[directive]}`,
+          {
+            append: true
+          }
+        );
+      }
+    }
+  }
+
+  // strip whitespace from cache-control header value to be consistent
+  response.header(
+    "cache-control",
+    response.headers["cache-control"].replace(/ /g, "")
+  );
+
+  return response;
+}

--- a/plugins/core/base/routes/tool-default.js
+++ b/plugins/core/base/routes/tool-default.js
@@ -1,79 +1,7 @@
 const Joi = require("joi");
-const Boom = require("boom");
-const Wreck = require("wreck");
-const querystring = require("querystring");
-
-async function handler(options, request, h, payload = null) {
-  const tool = request.server.settings.app.tools.get(`/${request.params.tool}`);
-
-  if (!tool) {
-    return Boom.notFound(`Tool ${request.params.tool} is not known`);
-  }
-
-  let queryString = "";
-  if (request.query && Object.keys(request.query).length > 0) {
-    queryString = querystring.stringify(request.query);
-  }
-
-  let toolResponse;
-  if (payload) {
-    toolResponse = await Wreck.post(
-      `${tool.baseUrl}/${request.params.path}?${queryString}`,
-      {
-        payload: payload
-      }
-    );
-  } else {
-    toolResponse = await Wreck.get(
-      `${tool.baseUrl}/${request.params.path}?${queryString}`
-    );
-  }
-
-  // prepare the response to add more headers
-  const response = h.response(toolResponse.payload);
-
-  // set all the headers from the tool response
-  for (let header in toolResponse.res.headers) {
-    response.header(header, toolResponse.res.headers[header]);
-  }
-
-  // add Cache-Control directives from config if we do not have no-cache set in the tool response
-  const responseCacheControl = Wreck.parseCacheControl(
-    toolResponse.res.headers["cache-control"]
-  );
-  if (responseCacheControl["no-cache"] !== true) {
-    const configCacheControl = await request.server.methods.getCacheControlDirectivesFromConfig(
-      options.get("/cache/cacheControl")
-    );
-    const defaultCacheControl = Wreck.parseCacheControl(
-      configCacheControl.join(",")
-    );
-
-    for (directive of Object.keys(defaultCacheControl)) {
-      // only add the default cache control if the directive is not present on the response from the tool
-      if (!responseCacheControl.hasOwnProperty(directive)) {
-        response.header(
-          "cache-control",
-          `${directive}=${defaultCacheControl[directive]}`,
-          {
-            append: true
-          }
-        );
-      }
-    }
-  }
-
-  // strip whitespace from cache-control header value to be consistent
-  response.header(
-    "cache-control",
-    response.headers["cache-control"].replace(/ /g, "")
-  );
-
-  return response;
-}
 
 module.exports = {
-  getGetRoute: function(options) {
+  getGetRoute: function (options) {
     return {
       path: "/tools/{tool}/{path*}",
       method: "GET",
@@ -95,27 +23,15 @@ module.exports = {
         }
       },
       handler: async (request, h) => {
-        let payload = null;
-        if (request.query.appendItemToPayload) {
-          // Get item with ignoreInactive set to true (gets inactive or active item)
-          const item = await request.server.methods.db.item.getById(
-            request.query.appendItemToPayload,
-            true
-          );
-          payload = {
-            item: item
-          };
-        }
-        return await Reflect.apply(handler, this, [
+        return await Reflect.apply(request.server.methods.getToolResponse, this, [
           options,
           request,
-          h,
-          payload
+          h
         ]);
       }
     };
   },
-  getPostRoute: function(options) {
+  getPostRoute: function (options) {
     return {
       path: "/tools/{tool}/{path*}",
       method: "POST",
@@ -138,19 +54,10 @@ module.exports = {
         }
       },
       handler: async (request, h) => {
-        if (request.query.appendItemToPayload) {
-          // Get item with ignoreInactive set to true (gets inactive or active item)
-          const item = await request.server.methods.db.item.getById(
-            request.query.appendItemToPayload,
-            true
-          );
-          request.payload.item = item;
-        }
-        return await Reflect.apply(handler, this, [
+        return await Reflect.apply(request.server.methods.getToolResponse, this, [
           options,
           request,
-          h,
-          request.payload
+          h
         ]);
       }
     };

--- a/plugins/core/base/routes/tool-schema.js
+++ b/plugins/core/base/routes/tool-schema.js
@@ -1,54 +1,62 @@
-const Boom = require('boom');
-const fetch = require('node-fetch');
-const jsonSchemaRefParser = require('json-schema-ref-parser');
+const Joi = require("joi");
+const jsonSchemaRefParser = require("json-schema-ref-parser");
 
-module.exports = {
-  schema: {
-    path: '/tools/{tool}/schema.json',
-    method: 'GET',
-    options: {
-      description: 'Returns the dereferenced schema by proxying the renderer service for the given tool as defined in the environment',
-      tags: ['api', 'editor']
-    },
-    handler: async (request, reply) => {
-      const toolConfig = request.server.settings.app.tools.get(`/${request.params.tool}`);
-      const dereferencedSchema = await getSchema(toolConfig, 'schema.json');
-      if (!dereferencedSchema) {
-        return Boom.notFound();
-      }
-      return dereferencedSchema;
-    }
-  },
-  displayOptionsSchema: {
-    path: '/tools/{tool}/display-options-schema.json',
-    method: 'GET',
-    options: {
-      description: 'Returns the dereferenced schema by proxying the renderer service for the given tool as defined in the environment',
-      tags: ['api', 'editor']
-    },
-    handler: async (request, reply) => {
-      const toolConfig = request.server.settings.app.tools.get(`/${request.params.tool}`);      
-      const dereferencedSchema = await getSchema(toolConfig, 'display-options-schema.json');
-      if (!dereferencedSchema) {
-        return Boom.notFound();
-      }
-      return dereferencedSchema;
-    }
-  }
-}
-
-async function getSchema(toolConfig, filename) {
-  const response = await fetch(`${toolConfig.baseUrl}/${filename}`);
-
-  if (!response.ok || response.status !== 200) {
-    return null;
-  }
-
-  const schema = await response.json();
-  const dereferencedSchema = await jsonSchemaRefParser.dereference(schema);
-
+async function getDereferencedSchema(schema) {
+  let dereferencedSchema = await jsonSchemaRefParser.dereference(schema);
   // delete the definition property as we do not need it anymore in the dereferenced schema
   delete dereferencedSchema.definitions;
-
   return dereferencedSchema;
 }
+
+module.exports = {
+  getSchema: function (options) {
+    return {
+      path: "/tools/{tool}/schema.json",
+      method: "GET",
+      options: {
+        description:
+          "Returns the dereferenced schema by proxying the renderer service for the given tool as defined in the environment",
+        tags: ["api", "editor"]
+      },
+      handler: async (request, h) => {
+        request.params.path = "schema.json";
+        const response = await Reflect.apply(request.server.methods.getToolResponse, this, [
+          options,
+          request,
+          h
+        ]);
+        const schema = JSON.parse(response.source.toString());
+        return getDereferencedSchema(schema);
+      }
+    }
+  },
+  getDisplayOptionsSchema: function (options) {
+    return {
+      path: "/tools/{tool}/display-options-schema.json",
+      method: "GET",
+      options: {
+        description:
+          "Returns the dereferenced schema by proxying the renderer service for the given tool as defined in the environment",
+        tags: ["api", "editor"],
+        validate: {
+          params: {
+            tool: Joi.string().required()
+          },
+          query: {
+            appendItemToPayload: Joi.string().optional()
+          }
+        }
+      },
+      handler: async (request, h) => {
+        request.params.path = "display-options-schema.json";
+        const response = await Reflect.apply(request.server.methods.getToolResponse, this, [
+          options,
+          request,
+          h
+        ]);
+        const schema = JSON.parse(response.source.toString());
+        return getDereferencedSchema(schema);
+      }
+    }
+  }
+};

--- a/plugins/core/base/routes/tool-schema.js
+++ b/plugins/core/base/routes/tool-schema.js
@@ -16,7 +16,15 @@ module.exports = {
       options: {
         description:
           "Returns the dereferenced schema by proxying the renderer service for the given tool as defined in the environment",
-        tags: ["api", "editor"]
+        tags: ["api", "editor"],
+        validate: {
+          params: {
+            tool: Joi.string().required()
+          },
+          query: {
+            appendItemToPayload: Joi.string().optional()
+          }
+        }
       },
       handler: async (request, h) => {
         request.params.path = "schema.json";

--- a/plugins/core/base/routes/tool-schema.js
+++ b/plugins/core/base/routes/tool-schema.js
@@ -9,7 +9,7 @@ async function getDereferencedSchema(schema) {
 }
 
 module.exports = {
-  getSchema: function (options) {
+  getSchema: function(options) {
     return {
       path: "/tools/{tool}/schema.json",
       method: "GET",
@@ -22,23 +22,23 @@ module.exports = {
             tool: Joi.string().required()
           },
           query: {
-            appendItemToPayload: Joi.string().optional()
+            appendItemToPayload: Joi.string().forbidden()
           }
         }
       },
       handler: async (request, h) => {
         request.params.path = "schema.json";
-        const response = await Reflect.apply(request.server.methods.getToolResponse, this, [
-          options,
-          request,
-          h
-        ]);
+        const response = await Reflect.apply(
+          request.server.methods.getToolResponse,
+          this,
+          [options, request, h]
+        );
         const schema = JSON.parse(response.source.toString());
         return getDereferencedSchema(schema);
       }
-    }
+    };
   },
-  getDisplayOptionsSchema: function (options) {
+  getDisplayOptionsSchema: function(options) {
     return {
       path: "/tools/{tool}/display-options-schema.json",
       method: "GET",
@@ -57,14 +57,14 @@ module.exports = {
       },
       handler: async (request, h) => {
         request.params.path = "display-options-schema.json";
-        const response = await Reflect.apply(request.server.methods.getToolResponse, this, [
-          options,
-          request,
-          h
-        ]);
+        const response = await Reflect.apply(
+          request.server.methods.getToolResponse,
+          this,
+          [options, request, h]
+        );
         const schema = JSON.parse(response.source.toString());
         return getDereferencedSchema(schema);
       }
-    }
+    };
   }
 };

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -563,7 +563,23 @@ lab.experiment("core editor endpoints", () => {
 });
 
 lab.experiment("core schema endpoints", () => {
-  it("returns the tool display option schema", async () => {
+  it("returns the tool schema", async () => {
+    const response = await server.inject("/tools/tool1/schema.json");
+    expect(response.statusCode).to.be.equal(200);
+    expect(response.result).to.be.an.object();
+    expect(response.result.properties.foo.type).to.be.equal("string");
+  });
+
+  it("returns the tool schema with appendItemToPayload query parameter", async () => {
+    const response = await server.inject(
+      "/tools/tool1/schema.json?appendItemToPayload=mock-item-active"
+    );
+    expect(response.statusCode).to.be.equal(200);
+    expect(response.result).to.be.an.object();
+    expect(response.result.properties.subtitle.type).to.be.equal("string");
+  });
+
+  it("returns the tool display options schema", async () => {
     const response = await server.inject(
       "/tools/tool1/display-options-schema.json"
     );
@@ -577,6 +593,15 @@ lab.experiment("core schema endpoints", () => {
       "/tools/tool2/display-options-schema.json"
     );
     expect(response.statusCode).to.be.equal(404);
+  });
+
+  it("returns the tool display options schema with appendItemToPayload query parameter", async () => {
+    const response = await server.inject(
+      "/tools/tool1/display-options-schema.json?appendItemToPayload=mock-item-active"
+    );
+    expect(response.statusCode).to.be.equal(200);
+    expect(response.result).to.be.an.object();
+    expect(response.result.properties.hideTitle.type).to.be.equal("boolean");
   });
 });
 

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -570,13 +570,11 @@ lab.experiment("core schema endpoints", () => {
     expect(response.result.properties.foo.type).to.be.equal("string");
   });
 
-  it("returns the tool schema with appendItemToPayload query parameter", async () => {
+  it("returns 400 for the tool schema with appendItemToPayload query parameter", async () => {
     const response = await server.inject(
       "/tools/tool1/schema.json?appendItemToPayload=mock-item-active"
     );
-    expect(response.statusCode).to.be.equal(200);
-    expect(response.result).to.be.an.object();
-    expect(response.result.properties.subtitle.type).to.be.equal("string");
+    expect(response.statusCode).to.be.equal(400);
   });
 
   it("returns the tool display options schema", async () => {

--- a/test/mock/items.js
+++ b/test/mock/items.js
@@ -17,12 +17,6 @@ module.exports = [
     title: "title",
     tool: "tool1",
     foo: "bar",
-    dynamicSchema: {
-      subtitle: {
-        title: "Untertitel",
-        type: "string"
-      }
-    },
     dynamicDisplayOptionsSchema: {
       hideTitle: {
         title: "Titel ausblenden",

--- a/test/mock/items.js
+++ b/test/mock/items.js
@@ -17,6 +17,18 @@ module.exports = [
     title: "title",
     tool: "tool1",
     foo: "bar",
+    dynamicSchema: {
+      subtitle: {
+        title: "Untertitel",
+        type: "string"
+      }
+    },
+    dynamicDisplayOptionsSchema: {
+      hideTitle: {
+        title: "Titel ausblenden",
+        type: "boolean"
+      }
+    },
     active: true
   },
   {

--- a/test/mock/tool1.js
+++ b/test/mock/tool1.js
@@ -49,20 +49,6 @@ server.route({
 });
 
 server.route({
-  method: "POST",
-  path: "/schema.json",
-  handler: function(request, h) {
-    if (request.payload.item.dynamicSchema !== undefined) {
-      schema.properties = Object.assign(
-        schema.properties,
-        request.payload.item.dynamicSchema
-      );
-    }
-    return schema;
-  }
-});
-
-server.route({
   method: "GET",
   path: "/display-options-schema.json",
   handler: function(request, h) {

--- a/test/mock/tool2.js
+++ b/test/mock/tool2.js
@@ -1,5 +1,5 @@
-const Hapi = require('hapi');
-const Boom = require('boom');
+const Hapi = require("hapi");
+const Boom = require("boom");
 
 const server = Hapi.server({
   port: 9998,
@@ -8,73 +8,88 @@ const server = Hapi.server({
   }
 });
 
+const schema = {
+  $schema: "http://json-schema.org/draft-04/schema#",
+  title: "mock",
+  type: "object",
+  properties: {
+    foo: {
+      type: "string"
+    }
+  },
+  required: ["foo"]
+};
+
 server.route({
-  method: 'GET',
-  path: '/',
+  method: "GET",
+  path: "/",
   handler: function(request, h) {
-    return 'mock tool running'
+    return "mock tool running";
   }
 });
 
 server.route({
-  method: 'GET',
-  path: '/schema.json',
+  method: "GET",
+  path: "/schema.json",
   handler: function(request, h) {
-    return `
-      {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "title": "mock",
-        "type": "object",
-        "properties": {
-          "foo": {
-            "type": "string"
-          }
-        },
-        "required": ["foo"]
-      }
-    `;
+    return schema;
   }
 });
 
 server.route({
-  method: 'POST',
-  path: '/rendering-info/mock',
+  method: "POST",
+  path: "/schema.json",
+  handler: function(request, h) {
+    if (request.payload.item.dynamicSchema !== undefined) {
+      schema.properties = Object.assign(
+        schema.properties,
+        request.payload.item.dynamicSchema
+      );
+    }
+    return schema;
+  }
+});
+
+server.route({
+  method: "POST",
+  path: "/rendering-info/mock",
   handler: function(request, h) {
     return {
-      markup: '<div></div>',
+      markup: "<div></div>",
       stylesheets: [
         {
-          name: 'mockstyle'
+          name: "mockstyle"
         }
       ],
       scripts: [
         {
-          name: 'mockscript'
+          name: "mockscript"
         }
       ]
-    }
+    };
   }
 });
 
 server.route({
-  method: 'POST',
-  path: '/rendering-info/fail',
+  method: "POST",
+  path: "/rendering-info/fail",
   handler: function(request, h) {
-    throw new Error('fail');
+    throw new Error("fail");
   }
 });
 
 server.route({
-  method: 'GET',
-  path: '/stylesheet/{name}.{hash}.css',
+  method: "GET",
+  path: "/stylesheet/{name}.{hash}.css",
   handler: function(request, h) {
-    let background = 'black';
+    let background = "black";
     if (request.query.background) {
       background = request.query.background;
     }
-    return h.response(`body { background: ${background}; }`)
-      .type('text/css')
-      .header('cache-control', `max-age=${60 * 60 * 24 * 365}, immutable`); // 1 year
+    return h
+      .response(`body { background: ${background}; }`)
+      .type("text/css")
+      .header("cache-control", `max-age=${60 * 60 * 24 * 365}, immutable`); // 1 year
   }
 });
 
@@ -82,4 +97,4 @@ module.exports = {
   start: async function() {
     await server.start();
   }
-}
+};

--- a/test/mock/tool2.js
+++ b/test/mock/tool2.js
@@ -38,20 +38,6 @@ server.route({
 
 server.route({
   method: "POST",
-  path: "/schema.json",
-  handler: function(request, h) {
-    if (request.payload.item.dynamicSchema !== undefined) {
-      schema.properties = Object.assign(
-        schema.properties,
-        request.payload.item.dynamicSchema
-      );
-    }
-    return schema;
-  }
-});
-
-server.route({
-  method: "POST",
   path: "/rendering-info/mock",
   handler: function(request, h) {
     return {


### PR DESCRIPTION
- This PR creates a new server method `getToolResponse` which now can be shared between the `schema` and `path` routes
- It is now possible to add the `appendItemToPayload` querystring in order to send the item with request to the schema route of the tool
- Additionally it puts the `getCacheControlDirectivesFromConfig` server method into is own file
- This branch is deployed on st-test. This can be tested by updating the displayOptionsSchema of [this item](https://q.st-test.nzz.ch/item/cd11d746cd1d1b6018d83e00b75db4ab) and checking the change [here](https://q.st-test.nzz.ch/livingdocs-component.html)