### PR TITLE
(editor config) server.settings.app.targets as object

### DIFF
--- a/plugins/core/editor/routes/targets.js
+++ b/plugins/core/editor/routes/targets.js
@@ -1,12 +1,27 @@
-
 module.exports = {
-  path: '/editor/targets',
-  method: 'GET',
+  path: "/editor/targets",
+  method: "GET",
   options: {
-    description: 'Returns all configured targets',
-    tags: ['api', 'editor']
+    description: "Returns all configured targets",
+    tags: ["api", "editor"]
   },
   handler: (request, h) => {
-    return request.server.settings.app.targets.get('');
+    const targets = request.server.settings.app.targets.get("");
+
+    // the follwoing is done for backwards compatibility reasons.
+    // Q-editor wants an array of targets, which makes sense.
+    // Q-server <= 6.3.2 wanted to have a confidence store with an array as the toplevel structure and returned this directly.
+    // this is not working with confidence >= 4 anymore as the store should be an object at the top level.
+    // the code here transforms the target object into an array of targets for Q-editor to consume
+    // the compatibility code could be removed in the future in a Q-server breaking change
+    if (Array.isArray(targets)) {
+      return targets;
+    }
+    return Object.keys(targets).map(key => {
+      return {
+        ...request.server.settings.app.targets.get(`/${key}`),
+        key: key
+      };
+    });
   }
-}
+};

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -555,10 +555,46 @@ lab.experiment("core editor endpoints", () => {
     );
   });
 
-  it("returns the target configs", async () => {
+  it("returns the target configs in the correct format", async () => {
     const response = await server.inject("/editor/targets");
     expect(response.result).to.be.an.array();
     expect(response.result[0].key).to.be.equal("pub1");
+  });
+
+  it("returns the target configs in the correct format for legacy confidence target configuration (array as top level)", async () => {
+    // this tests the backwards compatibility code in the editor/targets route
+    // handling the case where the target configuration is an array of targets instead of an object with targets as properties
+    // this can be removed in the next bc breaking change
+    // it has to be done to be compatible with confidence >= 4
+    const targets = [
+      {
+        key: "legacyFormatTargetKey",
+        label: "Pub1",
+        type: "web",
+        context: {
+          stylesheets: [
+            {
+              url:
+                "https://proxy.st-cdn.nzz.ch/context-service/stylesheet/all/nzz.ch.css"
+            }
+          ],
+          background: {
+            color: "white"
+          }
+        }
+      }
+    ];
+
+    const origTargets = server.settings.app.targets;
+    server.settings.app.targets = {
+      get: (key, criteria = {}) => {
+        return targets;
+      }
+    };
+    const response = await server.inject("/editor/targets");
+    expect(response.result).to.be.an.array();
+    expect(response.result[0].key).to.be.equal("legacyFormatTargetKey");
+    server.settings.app.targets = origTargets;
   });
 });
 


### PR DESCRIPTION
- server.settings.app.targets can be an object or an array, editor/targets route handles compatibility

this is done for backwards compatibility reasons.
Q-editor wants an array of targets, which makes sense.
Q-server <= 6.3.2 wanted to have a confidence store with an array as the toplevel structure and returned this directly.
this is not working with confidence >= 4 anymore as the store should be an object at the top level.
the code here transforms the target object into an array of targets for Q-editor to consume
the compatibility code could be removed in the future in a Q-server breaking change