### PR TITLE
DB abstraction improvements (bc breaking)

### DIFF
--- a/plugins/core/base/methods/getToolResponse.js
+++ b/plugins/core/base/methods/getToolResponse.js
@@ -6,7 +6,7 @@ exports.getToolResponse = async function(options, request, h) {
   if (request.query.appendItemToPayload) {
     // Get item with ignoreInactive set to true (gets inactive or active item)
     const item = await request.server.methods.db.item.getById({
-      appendItemToPayload: request.query.appendItemToPayload,
+      id: request.query.appendItemToPayload,
       ignoreInactive: true,
       session: {
         credentials: request.auth.credentials,

--- a/plugins/core/base/methods/getToolResponse.js
+++ b/plugins/core/base/methods/getToolResponse.js
@@ -5,10 +5,14 @@ const querystring = require("querystring");
 exports.getToolResponse = async function(options, request, h) {
   if (request.query.appendItemToPayload) {
     // Get item with ignoreInactive set to true (gets inactive or active item)
-    const item = await request.server.methods.db.item.getById(
-      request.query.appendItemToPayload,
-      true
-    );
+    const item = await request.server.methods.db.item.getById({
+      appendItemToPayload: request.query.appendItemToPayload,
+      ignoreInactive: true,
+      session: {
+        credentials: request.auth.credentials,
+        artifacts: request.auth.artifacts
+      }
+    });
     // do not allow appending an item of another tool
     if (request.params.tool !== item.tool) {
       return Boom.badRequest(

--- a/plugins/core/base/routes/admin/migration.js
+++ b/plugins/core/base/routes/admin/migration.js
@@ -27,12 +27,15 @@ module.exports = {
     }
 
     if (request.params.id) {
-      const ignoreInactive = true;
       try {
-        const item = await request.server.methods.db.item.getById(
-          request.params.id,
-          ignoreInactive
-        );
+        const item = await request.server.methods.db.item.getById({
+          id: request.params.id,
+          ignoreInactive: true,
+          session: {
+            credentials: request.auth.credentials,
+            artifacts: request.auth.artifacts
+          }
+        });
         const migrationStatus = await migrateItem(
           item,
           toolBaseUrl,
@@ -46,7 +49,13 @@ module.exports = {
         return err;
       }
     } else {
-      const items = await request.server.methods.db.item.getAllByTool(tool);
+      const items = await request.server.methods.db.item.getAllByTool({
+        tool,
+        session: {
+          credentials: request.auth.credentials,
+          artifacts: request.auth.artifacts
+        }
+      });
 
       let migrationStatuses = items.map(async item => {
         return await migrateItem(item, toolBaseUrl, request.server.app.db);

--- a/plugins/core/base/routes/item.js
+++ b/plugins/core/base/routes/item.js
@@ -176,11 +176,10 @@ module.exports = {
       doc.updatedBy = request.auth.credentials.name;
       docDiff.updatedBy = doc.updatedBy;
 
-      const ignoreInactive = true;
-      const oldDoc = await request.server.methods.db.item.getById(
-        request.payload._id,
-        ignoreInactive
-      );
+      const oldDoc = await request.server.methods.db.item.getById({
+        id: request.payload._id,
+        ignoreInactive: true
+      });
 
       // if the active state change to true, we set activateDate
       let isNewActive = false;

--- a/plugins/core/base/routes/search.js
+++ b/plugins/core/base/routes/search.js
@@ -23,10 +23,14 @@ module.exports = {
   handler: async (request, h) => {
     // Creates new object filterProperties which contains all properties but bookmark and limit
     const { bookmark, limit, ...filterProperties } = request.query;
-    return request.server.methods.db.item.search(
+    return request.server.methods.db.item.search({
       filterProperties,
       limit,
-      bookmark
-    );
+      bookmark,
+      session: {
+        credentials: request.auth.credentials,
+        artifacts: request.auth.artifacts
+      }
+    });
   }
 };

--- a/plugins/core/db/index.js
+++ b/plugins/core/db/index.js
@@ -160,6 +160,22 @@ module.exports = {
       return res;
     });
 
+    server.method("db.statistics.getNumberOfItems", async function({
+      since,
+      session
+    }) {
+      const options = {
+        reduce: "true"
+      };
+
+      if (!Number.isNaN(since)) {
+        options.startkey = since;
+      }
+
+      const res = await server.app.db.view("items", "numberOfItems", options);
+      return res.rows[0].value; // this returns the exact number of items in the database
+    });
+
     server.method("db.tools.getWithUserUsage", function({ username }) {
       const options = {
         startkey: [username],

--- a/plugins/core/db/index.js
+++ b/plugins/core/db/index.js
@@ -94,11 +94,18 @@ module.exports = {
       ignoreInactive,
       session
     }) {
-      const item = await server.app.db.get(id);
-      if (!ignoreInactive && item.active !== true) {
-        throw new Boom.forbidden("Item is not active");
+      try {
+        const item = await server.app.db.get(id);
+        if (!ignoreInactive && item.active !== true) {
+          throw Boom.forbidden("Item is not active");
+        }
+        return item;
+      } catch (err) {
+        if (err.isBoom) {
+          throw err;
+        }
+        throw new Boom(err.description, { statusCode: err.statusCode });
       }
-      return item;
     });
 
     // the session property passed here is

--- a/plugins/core/db/index.js
+++ b/plugins/core/db/index.js
@@ -173,7 +173,11 @@ module.exports = {
       }
 
       const res = await server.app.db.view("items", "numberOfItems", options);
-      return res.rows[0].value; // this returns the exact number of items in the database
+      try {
+        return res.rows[0].value; // this returns the exact number of items in the database
+      } catch (e) {
+        return 0;
+      }
     });
 
     server.method("db.tools.getWithUserUsage", function({ username }) {

--- a/plugins/core/editor/routes/tools-ordered-by-user-usage.js
+++ b/plugins/core/editor/routes/tools-ordered-by-user-usage.js
@@ -12,7 +12,13 @@ module.exports = {
   handler: async (request, h) => {
     const username = request.auth.credentials.name;
     const toolsWithUsageByUser = await request.server.methods.db.tools.getWithUserUsage(
-      username
+      {
+        username,
+        session: {
+          credentials: request.auth.credentials,
+          artifacts: request.auth.artifacts
+        }
+      }
     );
     return toolsWithUsageByUser
       .sort((a, b) => {

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -224,19 +224,24 @@ module.exports = {
     server.method(
       "renderingInfo.getRenderingInfoForId",
       async (id, target, requestToolRuntimeConfig, ignoreInactive, session) => {
-        const item = await server.methods.db.item.getById({
-          id,
-          ignoreInactive
-        });
-        // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
-        const itemStateInDb = true;
-        return server.methods.renderingInfo.getRenderingInfoForItem(
-          item,
-          target,
-          requestToolRuntimeConfig,
-          ignoreInactive,
-          itemStateInDb
-        );
+        try {
+          const item = await server.methods.db.item.getById({
+            id,
+            ignoreInactive,
+            session
+          });
+          // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
+          const itemStateInDb = true;
+          return server.methods.renderingInfo.getRenderingInfoForItem(
+            item,
+            target,
+            requestToolRuntimeConfig,
+            ignoreInactive,
+            itemStateInDb
+          );
+        } catch (err) {
+          throw err;
+        }
       }
     );
 

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -57,7 +57,11 @@ function getGetRenderingInfoRoute(config) {
           request.params.id,
           request.params.target,
           requestToolRuntimeConfig,
-          request.query.ignoreInactive
+          request.query.ignoreInactive,
+          {
+            credentials: request.auth.credentials,
+            artifacts: request.auth.artifacts
+          }
         );
         return h
           .response(renderingInfo)
@@ -219,14 +223,10 @@ module.exports = {
 
     server.method(
       "renderingInfo.getRenderingInfoForId",
-      async (id, target, requestToolRuntimeConfig, ignoreInactive) => {
+      async (id, target, requestToolRuntimeConfig, ignoreInactive, session) => {
         const item = await server.methods.db.item.getById({
           id,
-          ignoreInactive,
-          session: {
-            credentials: request.auth.credentials,
-            artifacts: request.auth.artifacts
-          }
+          ignoreInactive
         });
         // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
         const itemStateInDb = true;

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -220,7 +220,14 @@ module.exports = {
     server.method(
       "renderingInfo.getRenderingInfoForId",
       async (id, target, requestToolRuntimeConfig, ignoreInactive) => {
-        const item = await server.methods.db.item.getById(id, ignoreInactive);
+        const item = await server.methods.db.item.getById({
+          id,
+          ignoreInactive,
+          session: {
+            credentials: request.auth.credentials,
+            artifacts: request.auth.artifacts
+          }
+        });
         // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
         const itemStateInDb = true;
         return server.methods.renderingInfo.getRenderingInfoForItem(

--- a/plugins/screenshot/routes.js
+++ b/plugins/screenshot/routes.js
@@ -143,10 +143,14 @@ module.exports = {
           tags: ["api"]
         },
         handler: async (request, h) => {
-          const item = await request.server.methods.db.item.getById(
-            request.params.id,
-            request.query.ignoreInactive
-          );
+          const item = await request.server.methods.db.item.getById({
+            id: request.params.id,
+            ignoreInactive: request.query.ignoreInactive,
+            session: {
+              credentials: request.auth.credentials,
+              artifacts: request.auth.artifacts
+            }
+          });
           const screenshotConfig = Object.assign({}, request.query, {
             format: request.params.format
           });

--- a/plugins/statistics/index.js
+++ b/plugins/statistics/index.js
@@ -25,7 +25,7 @@ module.exports = {
           "returns the number of items. If given since the timestamp passed.",
         tags: ["api", "statistics", "non-critical"]
       },
-      handler: async (request, h) => {
+      handler: (request, h) => {
         return request.server.methods.db.statistics.getNumberOfItems({
           since: request.params.since,
           session: {

--- a/test/server.js
+++ b/test/server.js
@@ -16,7 +16,7 @@ function getServer() {
   server.auth.scheme("mock", function(server, options) {
     return {
       authenticate: function(request, h) {
-        return { credentials: "user" };
+        return h.authenticated({ credentials: "user" });
       }
     };
   });


### PR DESCRIPTION
This PR changes the API of the DB plugin server methods to take an object containing all the parameters. The new parameter is the the session information containing `credentials` and `artifacts` as returned from the auth scheme.

This allows implementors (like livingdocs) to implement their own storage layer and distribute storage systems by user (e.g. by projectId on the user).

It is a small breaking change that affects NZZ Q server implementation at a few points, but it's pretty easy to change.

I plan to do a breaking release of Q server with some other changes in august.