### PR TITLE
(statistics) fix response format of statistics endpoint

### DIFF
--- a/plugins/statistics/index.js
+++ b/plugins/statistics/index.js
@@ -25,14 +25,19 @@ module.exports = {
           "returns the number of items. If given since the timestamp passed.",
         tags: ["api", "statistics", "non-critical"]
       },
-      handler: (request, h) => {
-        return request.server.methods.db.statistics.getNumberOfItems({
-          since: request.params.since,
-          session: {
-            credentials: request.auth.credentials,
-            artifacts: request.auth.artifacts
+      handler: async (request, h) => {
+        const value = await request.server.methods.db.statistics.getNumberOfItems(
+          {
+            since: request.params.since,
+            session: {
+              credentials: request.auth.credentials,
+              artifacts: request.auth.artifacts
+            }
           }
-        });
+        );
+        return {
+          value: value
+        };
       }
     });
   }


### PR DESCRIPTION
- this fixes the format of the statistics response after breaking it here: https://github.com/nzzdev/Q-server/commit/3262dddb27ce128b61d122684d7b8ac5299ea510