### PR TITLE
(feat requestId) adds a requestId property to toolRuntimeConfig

### DIFF
--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -135,7 +135,7 @@ function getPostRenderingInfoRoute(config) {
 
       if (request.query.toolRuntimeConfig) {
         requestToolRuntimeConfig = request.query.toolRuntimeConfig;
-      } else {
+      } else if (request.payload.toolRuntimeConfig) {
         requestToolRuntimeConfig = request.payload.toolRuntimeConfig;
       }
 

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -5,6 +5,8 @@ const Hoek = require("@hapi/hoek");
 const querystring = require("querystring");
 const clone = require("clone");
 
+const crypto = require("crypto");
+
 const helpers = require("./helpers.js");
 const sizeValidationObject = require("./size-helpers.js").sizeValidationObject;
 const validateSize = require("./size-helpers.js").validateSize;
@@ -56,6 +58,11 @@ function getGetRenderingInfoRoute(config) {
 
         requestToolRuntimeConfig = request.query.toolRuntimeConfig;
       }
+
+      requestToolRuntimeConfig.requestId = crypto
+        .createHash("sha1")
+        .update(request.info.id)
+        .digest("hex");
 
       try {
         const renderingInfo = await request.server.methods.renderingInfo.getRenderingInfoForId(
@@ -143,6 +150,11 @@ function getPostRenderingInfoRoute(config) {
           }
         }
       }
+
+      requestToolRuntimeConfig.requestId = crypto
+        .createHash("sha1")
+        .update(request.info.id)
+        .digest("hex");
 
       // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
       const itemStateInDb = false;

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -59,10 +59,11 @@ function getGetRenderingInfoRoute(config) {
         requestToolRuntimeConfig = request.query.toolRuntimeConfig;
       }
 
-      requestToolRuntimeConfig.requestId = crypto
+      request.app.requestId = crypto
         .createHash("sha1")
         .update(request.info.id)
         .digest("hex");
+      requestToolRuntimeConfig.requestId = request.app.requestId;
 
       try {
         const renderingInfo = await request.server.methods.renderingInfo.getRenderingInfoForId(
@@ -151,10 +152,11 @@ function getPostRenderingInfoRoute(config) {
         }
       }
 
-      requestToolRuntimeConfig.requestId = crypto
+      request.app.requestId = crypto
         .createHash("sha1")
         .update(request.info.id)
         .digest("hex");
+      requestToolRuntimeConfig.requestId = request.app.requestId;
 
       // this property is passed through to the tool in the end to let it know if the item state is available in the database or not
       const itemStateInDb = false;


### PR DESCRIPTION
- the `requestId` property can be used wherever there needs to be an id that is unique for the rendering-info request
- we have several places where we use random numbers and pass them if necessary at the moment
- this PR generalised the solution and appends it to toolRuntimeConfig as this object is available everywhere already
- `request.info.id` is hashed because it could contain some information we might not want to expose
- `sha1` is used because it's the fastest and it doesn't have to be cryptographically safe
- this is specifically useful for our tracking implementation where we currently have this issue to solve: https://github.com/nzzdev/Q-server-nzz/issues/295