### PR TITLE
Fix font kerning

### DIFF
--- a/plugins/screenshot/helpers.js
+++ b/plugins/screenshot/helpers.js
@@ -3,7 +3,11 @@ const fetch = require("node-fetch");
 
 // start a chromium process here
 let browserPromise = puppeteer.launch({
-  args: ["--no-sandbox", "--disable-dev-shm-usage"]
+  args: [
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+    "--font-render-hinting=none"
+  ]
 });
 
 // fetches assets and returns a concatenated string containing everything fetched


### PR DESCRIPTION
Fix font kerning for headless Chromium in Linux.

### Comparison of font rendering in Q to print plugin
- Before this PR
- With `--font-render-hinting=medium`
- With `--font-render-hinting=none`
<img width="673" alt="no flag, medium, none" src="https://user-images.githubusercontent.com/47303530/68193316-2a92bf80-ffb3-11e9-9cac-6b8f3b5d2d11.png">

### Comparison of font rendering in png screenshot
- Before this PR
- With `--font-render-hinting=none`
<img width="299" alt="no flag, none" src="https://user-images.githubusercontent.com/47303530/68193317-2a92bf80-ffb3-11e9-8314-9e8c234521f6.png">

### How to reproduce
The issue does not seem to be present when running headless Chromium on macOS, but appears in production, where we have headless Chromium running inside a docker container.
Reproduced and fixed by running Chromium in a docker container on macOS.

See also
https://github.com/GoogleChrome/puppeteer/issues/661
https://github.com/GoogleChrome/puppeteer/issues/2410
https://stackoverflow.com/questions/52552573/kerning-issues-with-headless-chrome

Issue first discovered in the footnote of @benib's framed print of the first Q chart