### PR TITLE
Release 10.0.1

### DIFF
--- a/helper/custom-joi.js
+++ b/helper/custom-joi.js
@@ -1,0 +1,49 @@
+const Bourne = require("@hapi/bourne");
+const Joi = require("@hapi/joi");
+
+// As of Joi v16, strings are no longer automatically converted to objects/arrays,
+// even if the convert option of any.validate() is "true" (which is the default).
+// => A string such as '{"foo": "bar"}' is not valid for Joi.object().
+//    And '["foo", "bar"]' is not valid for Joi.array().
+// This is a problem when passing objects/arrays in HTTP query strings, where they
+// can only be represented as strings. This custom extension allows converting
+// objects/arrays to strings as it was done in Joi v15 and before.
+// Adapted from https://github.com/hapijs/joi/issues/2037
+// (section "Array and object string coercion")
+module.exports = Joi.extend(
+  {
+    type: "object",
+    base: Joi.object(),
+    coerce: {
+      from: "string",
+      method(value) {
+        if (value[0] !== "{" && !/^\s*\{/.test(value)) {
+          return;
+        }
+
+        try {
+          return { value: Bourne.parse(value) };
+        } catch (ignoreErr) {}
+      }
+    }
+  },
+  {
+    type: "array",
+    base: Joi.array(),
+    coerce: {
+      from: "string",
+      method(value) {
+        if (
+          typeof value !== "string" ||
+          (value[0] !== "[" && !/^\s*\[/.test(value))
+        ) {
+          return;
+        }
+
+        try {
+          return { value: Bourne.parse(value) };
+        } catch (ignoreErr) {}
+      }
+    }
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-server",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-server",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/core/base/routes/display-options-schema.js
+++ b/plugins/core/base/routes/display-options-schema.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../../../helper/custom-joi.js");
 const Bounce = require("@hapi/bounce");
 const deepmerge = require("deepmerge");
 

--- a/plugins/core/base/routes/item.js
+++ b/plugins/core/base/routes/item.js
@@ -1,5 +1,5 @@
 const Boom = require("@hapi/boom");
-const Joi = require("@hapi/joi");
+const Joi = require("../../../../helper/custom-joi.js");
 const Ajv = require("ajv");
 const ajv = new Ajv({ schemaId: "id" });
 // add draft-04 support explicit

--- a/plugins/core/base/routes/search.js
+++ b/plugins/core/base/routes/search.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../../../helper/custom-joi.js");
 
 module.exports = {
   path: "/search",

--- a/plugins/core/base/routes/tool-default.js
+++ b/plugins/core/base/routes/tool-default.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../../../helper/custom-joi.js");
 
 module.exports = {
   getGetRoute: function(options) {

--- a/plugins/core/base/routes/tool-schema.js
+++ b/plugins/core/base/routes/tool-schema.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../../../helper/custom-joi.js");
 const Boom = require("@hapi/boom");
 const jsonSchemaRefParser = require("json-schema-ref-parser");
 

--- a/plugins/core/editor/configSchemas.js
+++ b/plugins/core/editor/configSchemas.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../../helper/custom-joi.js");
 
 const target = Joi.object().pattern(
   Joi.string(), // the key needs to be a string

--- a/plugins/core/editor/routes/locales.js
+++ b/plugins/core/editor/routes/locales.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../../../helper/custom-joi.js");
 
 module.exports = {
   getGetToolsRoute: function() {

--- a/plugins/core/rendering-info/configSchemas.js
+++ b/plugins/core/rendering-info/configSchemas.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../../helper/custom-joi.js");
 
 const target = Joi.object().pattern(
   Joi.string(), // the key needs to be a string

--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -1,5 +1,5 @@
 const Boom = require("@hapi/boom");
-const Joi = require("@hapi/joi");
+const Joi = require("../../../helper/custom-joi.js");
 const Hoek = require("@hapi/hoek");
 
 const querystring = require("querystring");

--- a/plugins/core/rendering-info/size-helpers.js
+++ b/plugins/core/rendering-info/size-helpers.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../../helper/custom-joi.js");
 const Boom = require("@hapi/boom");
 
 // size, width and height are optional

--- a/plugins/screenshot/routes.js
+++ b/plugins/screenshot/routes.js
@@ -1,5 +1,5 @@
 const Boom = require("@hapi/boom");
-const Joi = require("@hapi/joi");
+const Joi = require("../../helper/custom-joi.js");
 
 const getScreenshotImage = require("./helpers.js").getScreenshotImage;
 const getScreenshotInfo = require("./helpers.js").getScreenshotInfo;

--- a/plugins/statistics/index.js
+++ b/plugins/statistics/index.js
@@ -1,4 +1,4 @@
-const Joi = require("@hapi/joi");
+const Joi = require("../../helper/custom-joi.js");
 const Boom = require("@hapi/boom");
 
 module.exports = {

--- a/test/e2e-tests.js
+++ b/test/e2e-tests.js
@@ -457,6 +457,13 @@ lab.experiment("core rendering-info", () => {
     }
   );
 
+  it("accepts a toolRuntimeConfig object", async () => {
+    const response = await server.inject(
+      '/rendering-info/mock-item-active/pub1?toolRuntimeConfig={"foo":"bar"}'
+    );
+    expect(response.statusCode).to.be.equal(200);
+  });
+
   it(
     "returns an error if rendering-info tool endpoint returns one",
     { plan: 1 },

--- a/test/mock/tool1.js
+++ b/test/mock/tool1.js
@@ -1,5 +1,5 @@
 const Hapi = require("@hapi/hapi");
-const Joi = require("@hapi/joi");
+const Joi = require("../../helper/custom-joi.js");
 
 const server = Hapi.server({
   port: 9999,

--- a/test/server.js
+++ b/test/server.js
@@ -1,5 +1,5 @@
 const Hapi = require("@hapi/hapi");
-const Joi = require("@hapi/joi");
+const Joi = require("../helper/custom-joi.js");
 
 function getServer() {
   let server = Hapi.server({

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -179,6 +179,24 @@ lab.experiment("rendering-info toolRuntimeConfig", () => {
     }
   );
 
+  it("validates a stringified object", async () => {
+    const Joi = require("../helper/custom-joi.js");
+
+    const schema = Joi.object({ foo: Joi.string() });
+    expect(schema.validate('{"foo": "bar"}')).to.equal({
+      value: { foo: "bar" }
+    });
+  });
+
+  it("validates a stringified array", async () => {
+    const Joi = require("../helper/custom-joi.js");
+
+    const schema = Joi.array().items(Joi.string());
+    expect(schema.validate('["foo", "bar"]')).to.equal({
+      value: ["foo", "bar"]
+    });
+  });
+
   it("fails to validate invalid size object", { plan: 10 }, async () => {
     const validateSize = require("../plugins/core/rendering-info/size-helpers.js")
       .validateSize;


### PR DESCRIPTION
- Fix joi validation of objects/arrays
Related to this breaking change in `@hapi/joi` v16:
Remove `Joi.object()` and `Joi.array()` string coerce
See hapijs/joi#2037