### PR TITLE
remove check to fix getAllByTool request

### DIFF
--- a/plugins/core/db/index.js
+++ b/plugins/core/db/index.js
@@ -127,9 +127,6 @@ module.exports = {
         reduce: false
       };
       const res = await server.app.db.view("items", "byTool", options);
-      if (!res.ok) {
-        throw new Error(`failed to getAllByTool ${tool}`);
-      }
       const items = res.rows.map(item => {
         return item.doc;
       });


### PR DESCRIPTION
Fix according to #192 

The request shows the following output, if the input is invalid:
```
{
    "statusCode": 501,
    "error": "Not Implemented",
    "message": "no base url configuration for <input> found"
}
```
