### PR TITLE
fix-toolBaseUrl

### DIFF
--- a/plugins/core/rendering-info/index.js
+++ b/plugins/core/rendering-info/index.js
@@ -27,7 +27,9 @@ function getGetRenderingInfoRoute(config) {
         },
         query: {
           toolRuntimeConfig: Joi.object({
-            size: Joi.object(sizeValidationObject).optional()
+            fileRequestBaseUrl: Joi.any().forbidden("Key 'fileRequestBaseUrl' is not allowed."),
+            toolBaseUrl: Joi.any().forbidden("Key 'toolBaseUrl' is not allowed."),
+            size: Joi.object(sizeValidationObject).optional(),
           }),
           ignoreInactive: Joi.boolean().optional(),
           noCache: Joi.boolean().optional()
@@ -120,7 +122,9 @@ function getPostRenderingInfoRoute(config) {
         payload: {
           item: Joi.object().required(),
           toolRuntimeConfig: Joi.object({
-            size: Joi.object(sizeValidationObject).optional()
+            fileRequestBaseUrl: Joi.any().forbidden("Key 'fileRequestBaseUrl' is not allowed."),
+            toolBaseUrl: Joi.any().forbidden("Key 'toolBaseUrl' is not allowed."),
+            size: Joi.object(sizeValidationObject).optional(),
           })
         },
         options: {


### PR DESCRIPTION
Fixes this security issue: https://tracking.nzzmg.ch/browse/NZZCH-5326

> The Quiz App is vulnerable to a reflected Cross-Site Scripting attack. The payload size is not limited since the included JavaScript file is hosted on a remote server.

While the vulnerability was discovered in the Q-quiz tool, it's actually a Q-server issue.
The two keys 'fileRequestBaseUrl' and 'toolBaseUrl' allowed the user to enter any URL, which would later be executed (which is veeery bad).

Example URL: https://q-server.st-staging.nzz.ch/view/news-app/ecf1db20c4ca6dcf6e7909906709f3f7?toolRuntimeConfig={%22fileRequestBaseUrl%22%3A%22https%3A%2F%2Fnachdenken.ch%2Fbb%22%2C%22toolBaseUrl%22%3A%22https%3A%2F%2Fnachdenken.ch%2Fbb%22%2C%22id%22%3A%22%22%2C%22displayOptions%22%3A{}%2C%22size%22%3A{%22width%22%3A[{%22value%22%3A641%2C%22unit%22%3A%22px%22%2C%22comparison%22%3A%22%3C%22}]}%2C%22requestId%22%3A%22566d37ffbb3c95b3615af927fca3413292689c5d%22}